### PR TITLE
Added dynamic style to JValues

### DIFF
--- a/ast/src/main/scala/org/json4s/JsonAST.scala
+++ b/ast/src/main/scala/org/json4s/JsonAST.scala
@@ -17,6 +17,7 @@
 package org.json4s
 
 import java.util.Locale.ENGLISH
+import scala.language.dynamics
 
 object JsonAST {
 
@@ -34,7 +35,7 @@ object JsonAST {
   /**
    * Data type for JSON AST.
    */
-  sealed abstract class JValue extends Diff.Diffable {
+  sealed abstract class JValue extends Diff.Diffable with Dynamic {
     type Values
 
 
@@ -46,6 +47,15 @@ object JsonAST {
      * </pre>
      */
     def values: Values
+    
+    /**
+     * Adds dynamic style to JValues. Only meaningful for JObjects
+     * <p>
+     * Example:<pre>
+     * JObject(JField("name",JString("joe"))::Nil).name == JString("joe")
+     * </pre>
+     */
+    def selectDynamic(name:String):JValue = JNothing
 
     /**
      * Return direct child elements.
@@ -148,6 +158,13 @@ object JsonAST {
       case o: JObject ⇒ Set(obj.toArray: _*) == Set(o.obj.toArray: _*)
       case _ ⇒ false
     }
+    
+    override def selectDynamic(name:String):JValue = {
+      obj.find{ case (n, v) => n == name} match {
+        case Some((_, v)) => v
+        case None => JNothing
+      }
+    }
   }
   case object JObject {
     def apply(fs: JField*): JObject = JObject(fs.toList)
@@ -190,4 +207,3 @@ object JsonAST {
     buf.toString
   }
 }
-

--- a/tests/src/test/scala/org/json4s/JsonDynamicAstSpec.scala
+++ b/tests/src/test/scala/org/json4s/JsonDynamicAstSpec.scala
@@ -1,0 +1,14 @@
+package org.json4s
+
+import org.specs2.mutable.Specification
+
+class JsonDynamicAstSpec extends Specification {
+  
+  import org.json4s.native.JsonMethods._
+  
+  "Dynamic access should allow transveral of objects" in {
+    val jsonTree = parse("""{"foo":{"bar": 3}}""")
+    jsonTree.foo.bar must_== JInt(3)
+  }
+
+}


### PR DESCRIPTION
Its only meaningful for JObjects right now.
For some reason JsonAST.scala resists any attempt to not do a complete
replacement. Perhaps its an old file?

Meaningful change on lines:
20
38
51-58
161-167
