### PR TITLE
Moved dynamic to a wrapping class

### DIFF
--- a/ast/src/main/scala/org/json4s/DynamicJValue.scala
+++ b/ast/src/main/scala/org/json4s/DynamicJValue.scala
@@ -1,0 +1,33 @@
+package org.json4s
+
+import JsonAST._
+import scala.language.dynamics
+
+// Should I make this into a subclass of Jvalue?
+case class DynamicJValue(jv: JValue) extends Dynamic {
+  /**
+     * Adds dynamic style to JValues. Only meaningful for JObjects
+     * <p>
+     * Example:<pre>
+     * JObject(JField("name",JString("joe"))::Nil).name == JString("joe")
+     * </pre>
+     */
+  def selectDynamic(name:String):DynamicJValue = jv match {
+    case jObj: JObject => {
+      jObj.obj.find{ case (n, v) => n == name} match {
+        case Some((_, v)) => new DynamicJValue(v)
+        case None => new DynamicJValue(JNothing)
+      }
+    }
+    case _ => new DynamicJValue(JNothing)
+  }
+  
+  override def hashCode():Int = jv.hashCode
+  
+}
+
+object DynamicJValue {
+  implicit def dynamicToJv(dynJv: DynamicJValue) = dynJv.jv
+  def dyn(jv:JValue) = new DynamicJValue(jv)
+}
+

--- a/ast/src/main/scala/org/json4s/JsonAST.scala
+++ b/ast/src/main/scala/org/json4s/JsonAST.scala
@@ -17,7 +17,6 @@
 package org.json4s
 
 import java.util.Locale.ENGLISH
-import scala.language.dynamics
 
 object JsonAST {
 
@@ -35,7 +34,7 @@ object JsonAST {
   /**
    * Data type for JSON AST.
    */
-  sealed abstract class JValue extends Diff.Diffable with Dynamic {
+  sealed abstract class JValue extends Diff.Diffable {
     type Values
 
 
@@ -48,15 +47,6 @@ object JsonAST {
      */
     def values: Values
     
-    /**
-     * Adds dynamic style to JValues. Only meaningful for JObjects
-     * <p>
-     * Example:<pre>
-     * JObject(JField("name",JString("joe"))::Nil).name == JString("joe")
-     * </pre>
-     */
-    def selectDynamic(name:String):JValue = JNothing
-
     /**
      * Return direct child elements.
      * <p>
@@ -157,13 +147,6 @@ object JsonAST {
     override def equals(that: Any): Boolean = that match {
       case o: JObject ⇒ Set(obj.toArray: _*) == Set(o.obj.toArray: _*)
       case _ ⇒ false
-    }
-    
-    override def selectDynamic(name:String):JValue = {
-      obj.find{ case (n, v) => n == name} match {
-        case Some((_, v)) => v
-        case None => JNothing
-      }
     }
   }
   case object JObject {

--- a/tests/src/test/scala/org/json4s/JsonDynamicAstSpec.scala
+++ b/tests/src/test/scala/org/json4s/JsonDynamicAstSpec.scala
@@ -5,10 +5,33 @@ import org.specs2.mutable.Specification
 class JsonDynamicAstSpec extends Specification {
   
   import org.json4s.native.JsonMethods._
+  import org.json4s.DynamicJValue._
+  
+  val tree = parse("""{"foo":{"bar": 3}}""")
   
   "Dynamic access should allow transveral of objects" in {
-    val jsonTree = parse("""{"foo":{"bar": 3}}""")
-    jsonTree.foo.bar must_== JInt(3)
+    val jsonTree = dyn(tree)
+    jsonTree.foo.bar must_== dyn(JInt(3))
+  }
+  
+  "Facilitate comparisons between DynamicJValues" in {
+    val jsonTree = dyn(tree)
+    jsonTree must_== dyn(parse("""{"foo":{"bar": 3}}"""))
+  }
+  
+  "Hashcode equality should work" in {
+    val jsonTree = dyn(tree)
+    jsonTree.foo.bar.hashCode must_== dyn(JInt(3)).hashCode
+  }
+  
+  "Hashcode equality should work for JValues and Dynamics" in {
+    val jsonTree = dyn(tree)
+    JInt(3).hashCode must_== jsonTree.foo.bar.hashCode
+  }
+  
+  "DynamicJValue should render correctly" in {
+    val jsonTree = dyn(tree)
+    compact(render(jsonTree)) must_== compact(render(tree))
   }
 
 }


### PR DESCRIPTION
Placement in the directory structure might need changing.

Currently has style of dyn(JValue).foo.bar

Operators such as \ appear to not work without extracting the JValue because of conflict with selectDynamic, so in those situations one would have to do
dyn(JValue).foo.bar.jv \ "stuff"
