### PR TITLE
Change remove() and removeField() to remove JValues, rather than setting them to JNothing

### DIFF
--- a/tests/src/test/scala/org/json4s/DiffExamples.scala
+++ b/tests/src/test/scala/org/json4s/DiffExamples.scala
@@ -74,6 +74,13 @@ abstract class DiffExamples[T](mod: String) extends Specification with JsonMetho
     json1 diff json2 must_== Diff(expectedChanges, expectedAdditions, expectedDeletions)
   }
 
+  "After adding and removing a field, there should be no difference" in {
+    import JsonDSL._
+    val addition = parse("""{"author":"Martin"}""")
+    val scala2 = scala1 merge addition removeField { _ == JField("author", "Martin") }
+    scala1 diff scala2 must_== Diff(JNothing, JNothing, JNothing)
+  }
+
   private def read(resource: String) =
     parse(scala.io.Source.fromInputStream(getClass.getResourceAsStream(resource)).getLines().mkString)
 }

--- a/tests/src/test/scala/org/json4s/Examples.scala
+++ b/tests/src/test/scala/org/json4s/Examples.scala
@@ -122,9 +122,24 @@ abstract class Examples[T](mod: String) extends Specification with JsonMethods[T
         """{"PERSON":{"NAME":"Joe","AGE":35,"SPOUSE":{"PERSON":{"NAME":"Marilyn","AGE":33}}}}"""
     }
 
-    "Remove example" in {
+    "Remove Field example" in {
       val json = parse(person) removeField { _ == JField("name", "Marilyn") }
-      compact(render(json \\ "name")) must_== """{"name":"Joe"}"""
+      (json \\ "name") must_== JString("Joe")
+      compact(render(json \\ "name")) must_== "\"Joe\""
+    }
+
+    "Remove example" in {
+      val json = parse(person) remove { _ == JString("Marilyn") }
+      (json \\ "name") must_== JString("Joe")
+      compact(render(json \\ "name")) must_== "\"Joe\""
+    }
+
+    "XPath operator should behave the same after adding and removing a second field with the same name" in {
+      val json = parse(lotto)
+      val addition = parse("""{"lotto-two": {"lotto-id": 6}}""")
+      val json2 = json merge addition removeField { _ == JField("lotto-id", 6) }
+
+      (json2 \\ "lotto-id") must_== (json \\ "lotto-id")
     }
 
     "Queries on person example" in {

--- a/tests/src/test/scala/org/json4s/JsonAstSpec.scala
+++ b/tests/src/test/scala/org/json4s/JsonAstSpec.scala
@@ -96,11 +96,22 @@ object JsonAstSpec extends Specification with JValueGen with ScalaCheck {
     "Remove removes only matching elements" in {
       forAllNoShrink(genJValue, genJValueClass) { (json: JValue, x: Class[_ <: JValue]) => {
         val removed = json remove typePredicate(x)
-        val Diff(c, a, d) = json diff removed
         val elemsLeft = removed filter {
           case _ => true
         }
-        (c must_== JNothing) and (a must_== JNothing) and (elemsLeft.forall(_.getClass != x) must beTrue)
+        (elemsLeft.forall(_.getClass != x) must beTrue)
+      }}
+    }
+
+    "noNulls removes JNulls and JNothings" in {
+      forAllNoShrink(genJValue, genJValueClass) { (json: JValue, x: Class[_ <: JValue]) => {
+        val noNulls = json.noNulls
+        val elemsLeft = noNulls filter {
+          case _ => true
+        }
+        //noNulls can remove everything in which case we get a JNothing, otherwise there should be no JNulls or JNothings
+        (noNulls must_== JNothing) or
+        (elemsLeft.forall(e => e != JNull && e != JNothing) must beTrue)
       }}
     }
 


### PR DESCRIPTION
This pull request changes the current behaviour of remove() and removeField() from setting `JValue`s and `JField`s to `JNothing` to actually removing them instead. Examples showing the reasoning behind the change are below. I've added unit tests for these examples.
# Fixing Inconsistent Diff Behaviour

Say you start with the following `JObject`:

```
{
    "language": "Scala"
}
```

and you add the field `"author": "Martin"`, but then remove it, you should have a `JObject` identical to the original. If you render the two `JObject`s out they look the same, however if you run a diff, you get the following:

```
Diff(JNothing,JObject(List((author,JNothing))),JNothing)
```

The fact a remove has happened in the past shouldn't change the way diff works. This pull request makes diff work in the same way after a remove as if you were diffing two identical `JObject`s and you instead get

```
Diff(JNothing,JNothing,JNothing)
```
# Fixing Inconsistent XPath behaviour

This is similar to the diff problem. Say you start with the following `JObject`:

```
{
    "language": "Scala"
    "related": {}
}
```

If you run `jval \\ "language"` you get a `JString("Scala")`.

If you and you add a field `related.language` and then remove it, you should have a `JObject` identical to the original. However if you now run `jval \\ "language"` you get a `JObject(List(("language",JString("scala")), ("language",JNothing)))`

This pull request removes this inconsistent behaviour.
# noNulls now works as advertised

The `noNulls` method has the following comment in the code

```
/**
* Remove the [[org.json4s.JsonAST.JNothing]] and [[org.json4s.JsonAST.JNull]] from
* a [[org.json4s.JsonAST.JArray]] or [[org.json4s.JsonAST.JObject]]
*/
```

However this wasn't true. `noNulls` would actually turn any `JNull`s into `JNothing`s and wouldn't change `JNothing`s at all. This pull request fixes this.
