### PR TITLE
Added return type into JsonDSL Implicits for overrideing

### DIFF
--- a/ast/src/main/scala/org/json4s/JsonDSL.scala
+++ b/ast/src/main/scala/org/json4s/JsonDSL.scala
@@ -41,14 +41,14 @@ trait DoubleMode { self: Implicits ⇒
 }
 object DoubleMode extends Implicits with DoubleMode
 trait Implicits {
-  implicit def int2jvalue(x: Int) = JInt(x)
-  implicit def long2jvalue(x: Long) = JInt(x)
-  implicit def bigint2jvalue(x: BigInt) = JInt(x)
+  implicit def int2jvalue(x: Int): JValue = JInt(x)
+  implicit def long2jvalue(x: Long): JValue = JInt(x)
+  implicit def bigint2jvalue(x: BigInt): JValue = JInt(x)
   implicit def double2jvalue(x: Double): JValue
   implicit def float2jvalue(x: Float): JValue
   implicit def bigdecimal2jvalue(x: BigDecimal): JValue
-  implicit def boolean2jvalue(x: Boolean) = JBool(x)
-  implicit def string2jvalue(x: String) = JString(x)
+  implicit def boolean2jvalue(x: Boolean): JValue = JBool(x)
+  implicit def string2jvalue(x: String): JValue = JString(x)
 }
 
 /**

--- a/tests/src/test/scala/org/json4s/JsonDSLSpec.scala
+++ b/tests/src/test/scala/org/json4s/JsonDSLSpec.scala
@@ -1,0 +1,30 @@
+package org.json4s
+
+import org.specs2.mutable.Specification
+import org.scalacheck._
+import org.scalacheck.Prop.forAllNoShrink
+import org.specs2.ScalaCheck
+import org.specs2.matcher.MatchResult
+
+object JsonDSLSpec extends Specification with JValueGen with ScalaCheck {
+
+  ("JSON DSL Specification") should {
+    "build Json" in {
+      import JsonDSL._
+      val buildProp = (intValue: Int, strValue: String) =>
+        (("intValue" -> intValue) ~ ("strValue" -> strValue)) must_== JObject("intValue" -> JInt(intValue), ("strValue", JString(strValue)))
+      prop(buildProp)
+    }
+
+    "customize value type" in {
+      object CustomJsonDSL extends JsonDSL with DoubleMode {
+        override implicit def int2jvalue(x: Int): JValue = JString(x.toString)
+      }
+      import CustomJsonDSL._
+      val buildProp = (intValue: Int, strValue: String) =>
+        (("intValue" -> intValue) ~ ("strValue" -> strValue)) must_== JObject(("intValue", JString(intValue.toString)), ("strValue", JString(strValue)))
+      prop(buildProp)
+    }
+  }
+
+}


### PR DESCRIPTION
I need a function that can represent numeric values by `JString`, because I avoid rounding errors and digit overflow in JavaScript.

However, JsonDSL is not be able to customize primitive result types.

This request makes JsonDSL enable to change result type of primitive values.

like following

``` scala
object CustomJsonDSL extends JsonDSL with DoubleMode {
  override implicit def int2jvalue(x: Int): JValue = JString(x.toString)
  override implicit def long2jvalue(x: Long): JValue = JString(x.toString)
}
import CustomJsonDSL._

(("int" -> 10) ~ ("long" -> 20L)) must_== JObject(("int", JString("10")), ("long", JString("20")))
```
