### PR TITLE
fix for unwanted fields coma separators between omitted Option[T] fields

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -71,10 +71,11 @@ object Extraction {
     def prependTypeHint(clazz: Class[_], o: JObject) =
       JObject(JField(formats.typeHintFieldName, JString(formats.typeHints.hintFor(clazz))) :: o.obj)
 
-    def addField(name: String, v: Any, obj: JsonWriter[T]) = {
-      val f = obj.startField(name)
-      decomposeWithBuilder(v, f)
-    }
+    def addField(name: String, v: Any, obj: JsonWriter[T]) = 
+      if (v != None) {
+        val f = obj.startField(name)
+        decomposeWithBuilder(v, f)
+      }
 
     val serializer = formats.typeHints.serialize
     val any = a.asInstanceOf[AnyRef]


### PR DESCRIPTION
I discovered that the serialization of class case with several (more than two in succession) Option[T] fields produce invalid JSON object with unwanted comma separators.

Example:

``` scala
case class OptionalValues(a: Option[String], b: Option[String], c: Option[String])

write(OptionalValues(None, None, Some("stringValue"))) // => { , "c": "stringValue"}
```
