### PR TITLE
Added support for Either

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -71,7 +71,7 @@ object Extraction {
     def prependTypeHint(clazz: Class[_], o: JObject) =
       JObject(JField(formats.typeHintFieldName, JString(formats.typeHints.hintFor(clazz))) :: o.obj)
 
-    def addField(name: String, v: Any, obj: JsonWriter[T]) = 
+    def addField(name: String, v: Any, obj: JsonWriter[T]) =
       if (v != None) {
         val f = obj.startField(name)
         decomposeWithBuilder(v, f)
@@ -121,6 +121,13 @@ object Extraction {
         val v = any.asInstanceOf[Option[_]]
         if (v.isDefined) {
           decomposeWithBuilder(v.get, current)
+        }
+      } else if (classOf[Either[_, _]].isAssignableFrom(k)) {
+        val v = any.asInstanceOf[Either[_, _]]
+        if (v.isLeft) {
+          decomposeWithBuilder(v.left.get, current)
+        } else {
+          decomposeWithBuilder(v.right.get, current)
         }
       } else {
         val klass = Reflector.scalaTypeOf(k)
@@ -271,7 +278,16 @@ object Extraction {
   }
 
   def extract(json: JValue, scalaType: ScalaType)(implicit formats: Formats): Any = {
-    if (scalaType.isOption) {
+    if (scalaType.isEither) {
+      import scala.util.Try
+      Try {
+        Left(extract(json, scalaType.typeArgs(0)))
+      } orElse Try {
+        Right(extract(json, scalaType.typeArgs(1)))
+      } recover {
+        case e: Exception => fail("Expected value but got " + json)
+      } get
+    } else if (scalaType.isOption) {
       customOrElse(scalaType, json)(_.toOption flatMap (j => Option(extract(j, scalaType.typeArgs.head))))
     } else if (scalaType.isMap) {
       val ta = scalaType.typeArgs(1)

--- a/core/src/main/scala/org/json4s/reflect/descriptors.scala
+++ b/core/src/main/scala/org/json4s/reflect/descriptors.scala
@@ -139,6 +139,7 @@ class ScalaType(private val manifest: Manifest[_]) extends Equals {
   def isMap = classOf[Map[_, _]].isAssignableFrom(erasure)
   def isCollection = erasure.isArray || classOf[Iterable[_]].isAssignableFrom(erasure) || classOf[java.util.Collection[_]].isAssignableFrom(erasure)
   def isOption = classOf[Option[_]].isAssignableFrom(erasure)
+  def isEither = classOf[Either[_, _]].isAssignableFrom(erasure)
   def <:<(that: ScalaType): Boolean = manifest <:< that.manifest
   def >:>(that: ScalaType): Boolean = manifest >:> that.manifest
 

--- a/tests/src/test/scala/org/json4s/Either.scala
+++ b/tests/src/test/scala/org/json4s/Either.scala
@@ -1,0 +1,67 @@
+package org.json4s
+
+import org.specs2.mutable.Specification
+
+object EitherTest {
+
+  case class OptionInt(i: Option[Int])
+
+  case class EitherIntString(i: Either[Int, String])
+
+  case class EitherStringInt(i: Either[String, Int])
+
+  case class EitherListIntListString(i: Either[List[String], List[Int]])
+
+  case class EitherListStringListInt(i: Either[List[Int], List[String]])
+
+  case class EitherListListStringMapStringInt(i: Either[List[List[String]], List[Map[String, List[Int]]]])
+
+}
+
+object JacksonEitherTest extends EitherTest[JValue]("Native") with jackson.JsonMethods
+
+abstract class EitherTest[T](mod: String) extends Specification with JsonMethods[T] {
+
+  import EitherTest._
+
+  implicit val formats: Formats = DefaultFormats + ShortTypeHints(List(classOf[Either[_, _]], classOf[List[_]]))
+
+
+  (mod + " EitherTest Specification") should {
+    "See that it works for Option[Int]" in {
+      val opt = OptionInt(Some(39))
+      Extraction.decompose(opt).extract[OptionInt].i.get must_== 39
+    }
+
+    "Work for Either[Int, String]" in {
+      val opt = EitherIntString(Left(39))
+      Extraction.decompose(opt).extract[EitherIntString].i.left.get must_== 39
+
+      val opt2 = EitherIntString(Right("hello"))
+      Extraction.decompose(opt2).extract[EitherIntString].i.right.get must_== "hello"
+    }
+
+    "Work for Either[List[Int], List[String]]" in {
+      val opt = EitherListStringListInt(Left(List(1, 2, 3)))
+      Extraction.decompose(opt).extract[EitherListStringListInt].i.left.get must_== List(1, 2, 3)
+
+      val opt2 = EitherListStringListInt(Right(List("hello", "world")))
+      Extraction.decompose(opt2).extract[EitherListStringListInt].i.right.get must_== List("hello", "world")
+    }
+
+    "Work for Either[List[List[String]], List[Map[String, List[Int]]]]" in {
+      val opt = EitherListListStringMapStringInt(Left(List(List("a", "b", "c"), List("d", "e", "f"))))
+      Extraction.decompose(opt).extract[EitherListListStringMapStringInt].i.left.get must_== List(List("a", "b", "c"), List("d", "e", "f"))
+
+      val opt2 = EitherListListStringMapStringInt(Right(
+        List(
+          Map("hello" -> List(5, 4, 3, 2, 1), "world" -> List(10, 20, 30)),
+          Map("bye" -> List(10), "world" -> List(10, 20, 30))
+        )))
+      Extraction.decompose(opt2).extract[EitherListListStringMapStringInt].i.right.get must_== List(
+        Map("hello" -> List(5, 4, 3, 2, 1), "world" -> List(10, 20, 30)),
+        Map("bye" -> List(10), "world" -> List(10, 20, 30))
+      )
+    }
+  }
+}


### PR DESCRIPTION
Hi,

We have a use case in our team when parsing a Json that we need to use Either. That is, in some scenarios we receive one type for a given field, in other scenarios we receive a completely different type in that field. Given that scenario we have a `case class OurStructure(value: Either[List[Something], SomethingElse])`. Changing the Json API we consume is not an option.

We were using Jerkson with Scala 2.9 and moved to 2.10 and Json4s. Now all the Eithers that were working before broke.

There is no support for Either in the library so we tried creating a custom serializer... and failed :(.

We were able to get it working for Eithers of basic types. It doesn't work though for Eithers of types with type arguments of their own (i.e Either[List[Int], Int] fails on the List). IMHO the CustomSerializer simply can't work in that case. It provides a TypeInfo instead of a ScalaType and thus loses all the information it should have carried along with the Manifest from the original 'extract' at call site. There is no way to determine the argument type of the List.

After concluding that CustomSerializer can not possibly work we decided to add direct support for it. Here is a working draft of how to work with Eithers. There are some tests included showing that it works. Please let me know what you think and feel free to change it or ask for me for changes.

Thanks,
Tomás Lázaro
