### PR TITLE
Mark a change in value type as a change rather than an add and a remove

### DIFF
--- a/ast/src/main/scala/org/json4s/Diff.scala
+++ b/ast/src/main/scala/org/json4s/Diff.scala
@@ -63,7 +63,9 @@ object Diff {
     case (JDecimal(x), JDecimal(y)) if (x != y) => Diff(JDecimal(y), JNothing, JNothing)
     case (JString(x), JString(y)) if (x != y) => Diff(JString(y), JNothing, JNothing)
     case (JBool(x), JBool(y)) if (x != y) => Diff(JBool(y), JNothing, JNothing)
-    case (x, y) => Diff(JNothing, y, x)
+    case (JNothing, x) => Diff(JNothing, x, JNothing)
+    case (x, JNothing) => Diff(JNothing, JNothing, x)
+    case (x, y) => Diff(y, JNothing, JNothing)
   }
 
   private def diffFields(vs1: List[JField], vs2: List[JField]) = {

--- a/tests/src/test/scala/org/json4s/DiffExamples.scala
+++ b/tests/src/test/scala/org/json4s/DiffExamples.scala
@@ -81,6 +81,12 @@ abstract class DiffExamples[T](mod: String) extends Specification with JsonMetho
     scala1 diff scala2 must_== Diff(JNothing, JNothing, JNothing)
   }
 
+  "Changing value type results in a change diff" in {
+    val original = JObject("a" -> JInt(1))
+    val changed = JObject("a" -> JString("different"))
+    original diff changed must_== Diff(changed, JNothing, JNothing)
+  }
+
   private def read(resource: String) =
     parse(scala.io.Source.fromInputStream(getClass.getResourceAsStream(resource)).getLines().mkString)
 }


### PR DESCRIPTION
Previously the result of the new spec I've added was:
Diff(JNothing, JObject("a" -> "different"), JObject("a" -> 1))

A change of type is a change, not a removal and an addition
