### PR TITLE
return None if JValue is JNull in JValue#toOption

### DIFF
--- a/ast/src/main/scala/org/json4s/JsonAST.scala
+++ b/ast/src/main/scala/org/json4s/JsonAST.scala
@@ -144,18 +144,18 @@ object JsonAST {
     }
 
     /**
-     * When this [[org.json4s.JValue]] is a [[org.json4s.JNothing]], this method returns [[scala.None]]
+     * When this [[org.json4s.JValue]] is a [[org.json4s.JNothing]] or [[org.json4s.JNull]], this method returns [[scala.None]]
      * When it has a value it will return [[scala.Some]]
      */
     @deprecated("Use toOption instead", "3.1.0")
     def toOpt: Option[JValue] = toOption
     
     /**
-     * When this [[org.json4s.JValue]] is a [[org.json4s.JNothing]], this method returns [[scala.None]]
+     * When this [[org.json4s.JValue]] is a [[org.json4s.JNothing]] or [[org.json4s.JNull]], this method returns [[scala.None]]
      * When it has a value it will return [[scala.Some]]
      */
     def toOption: Option[JValue] = this match {
-      case JNothing ⇒ None
+      case JNothing | JNull ⇒ None
       case json ⇒ Some(json)
     }
   }


### PR DESCRIPTION
For the same reason.

> My opinion is that null should be used to combine Java API, but otherwise we use None.
> https://github.com/json4s/json4s/issues/89
