### PR TITLE
Use Option.apply insted of toOpt in ExtractableJsonAstNode#getAs

### DIFF
--- a/core/src/main/scala/org/json4s/ExtractableJsonAstNode.scala
+++ b/core/src/main/scala/org/json4s/ExtractableJsonAstNode.scala
@@ -87,7 +87,7 @@ class ExtractableJsonAstNode(jv: JValue) {
    * }}}
    */
   def getAs[A](implicit reader: Reader[A], mf: scala.reflect.Manifest[A]): Option[A] = try {
-    jv.toOption map reader.read
+    Option(reader.read(jv))
   } catch { case _: Throwable ⇒ None }
 
   /**


### PR DESCRIPTION
`ExtractableJsonAstNode#getAs[A]` has the same problem as https://github.com/json4s/json4s/issues/89
I think `getAs` should behave similar to `extractOpt`.
@dozed `extractOpt` don't return `Some(null)` after #89 was fixed.

``` scala
scala> val json = parse(""" {"x": null} """)
json: org.json4s.JValue = JObject(List((x,JNull)))

//the present
(json \ "x").getAs[String] //Some(null)
(json \ "x").extractOpt[String] //None

//this PR
(json \ "x").getAs[String] //None
```
