### PR TITLE
Returning a JArray if multiple matching fields are found.

### DIFF
--- a/core/src/main/scala/org/json4s/MonadicJValue.scala
+++ b/core/src/main/scala/org/json4s/MonadicJValue.scala
@@ -51,10 +51,7 @@ class MonadicJValue(jv: JValue) {
       case (acc, _) => acc
     }
 
-    values match {
-      case x :: Nil => x
-      case xs => JArray(xs.reverse)
-    }
+    JArray(values.reverse)
   }
 
   /**

--- a/tests/src/test/scala/org/json4s/Examples.scala
+++ b/tests/src/test/scala/org/json4s/Examples.scala
@@ -111,8 +111,13 @@ abstract class Examples[T](mod: String) extends Specification with JsonMethods[T
       val renderedPerson = pretty(render(json))
       json must_== parse(renderedPerson)
       render(json) must_== render(personDSL)
-      compact(render(json \\ "name")) must_== """["Joe","Marilyn"]"""
       compact(render(json \ "person" \ "name")) must_== "\"Joe\""
+    }
+
+    "Recursive navigation example" in {
+      val json = parse(person)
+      compact(render(json \\ "name")) must_== """["Joe","Marilyn"]"""
+      compact(render(parse("""{ "name": "Joe"}""") \\ "name" )) must_== """["Joe"]"""
     }
 
     "Transformation example" in {
@@ -124,14 +129,14 @@ abstract class Examples[T](mod: String) extends Specification with JsonMethods[T
 
     "Remove Field example" in {
       val json = parse(person) removeField { _ == JField("name", "Marilyn") }
-      (json \\ "name") must_== JString("Joe")
-      compact(render(json \\ "name")) must_== "\"Joe\""
+      (json \\ "name") must_== JArray(List(JString("Joe")))
+      compact(render(json \\ "name")) must_== """["Joe"]"""
     }
 
     "Remove example" in {
       val json = parse(person) remove { _ == JString("Marilyn") }
-      (json \\ "name") must_== JString("Joe")
-      compact(render(json \\ "name")) must_== "\"Joe\""
+      (json \\ "name") must_== JArray(List(JString("Joe")))
+      compact(render(json \\ "name")) must_== """["Joe"]"""
     }
 
     "XPath operator should behave the same after adding and removing a second field with the same name" in {


### PR DESCRIPTION
Changed the return type of \\ if multiple fields are found, so it matches the behaviour of \.

``` scala
val json = parse(
  """
    |{
    |  "aaa": [
    |     {
    |       "bbb": 100
    |     },
    |     {
    |       "bbb": 200
    |     }
    |  ]
    |}
  """.stripMargin)

json \\ "bbb"
// previous: JObject(List(("bbb", JInt(100)), ("bbb", JInt(200))))
// now: JArray(List(JInt(100), JInt(200)))

(json \ "aaa" \ "bbb") == (json \\ "bbb")  // true
```
