### PR TITLE
Fix string exception in near method of ParserUtil

### DIFF
--- a/core/src/main/scala/org/json4s/ParserUtil.scala
+++ b/core/src/main/scala/org/json4s/ParserUtil.scala
@@ -104,7 +104,7 @@ object ParserUtil {
       }
     }
 
-    def near = new String(segment, (cur-20) max 0, (cur + 1) min Segments.segmentSize)
+    def near = new String(segment, (cur-20) max 0, 20 min cur)
 
     def release = segments.foreach(Segments.release)
 


### PR DESCRIPTION
- Java String's 2nd and 3rd actor parameter are offset/length instead of  begin/end

Java 7 SE Doc:

> String(byte[] bytes, int offset, int length)
> Constructs a new String by decoding the specified subarray of bytes using the platform's default charset.

Signed-off-by: Wang Xu gnawux@gmail.com
