### PR TITLE
use local timezone

### DIFF
--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -325,11 +325,7 @@ trait Formats { self: Formats =>
 
       def format(d: Date) = formatter.format(d)
 
-      private[this] def formatter = {
-        val f = df()
-        f.setTimeZone(DefaultFormats.UTC)
-        f
-      }
+      private[this] def formatter = df()
     }
 
     protected def dateFormatter: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")

--- a/tests/src/test/scala/org/json4s/ext/JodaTimeSerializerSpec.scala
+++ b/tests/src/test/scala/org/json4s/ext/JodaTimeSerializerSpec.scala
@@ -51,7 +51,7 @@ abstract class JodaTimeSerializerSpec(mod: String) extends Specification {
         override def dateFormatter = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss'Z'")
       } ++ JodaTimeSerializers.all
 
-      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0, DateTimeZone.UTC), new DateMidnight(2011, 1, 16, DateTimeZone.UTC))
+      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0), new DateMidnight(2011, 1, 16))
       val ser = s.write(x)
       ser must_== """{"dt":"2011-01-16 10:32:00Z","dm":"2011-01-16 00:00:00Z"}"""
     }

--- a/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
+++ b/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
@@ -277,13 +277,20 @@ object CustomSerializerExamples extends Specification {
     }
   ))
 
+  def losslessUTC = {
+    val sdf = DefaultFormats.losslessDate.get()
+    sdf.setTimeZone(DefaultFormats.UTC)
+    sdf
+  }
+
   class DateSerializer extends CustomSerializer[Date](format => (
     {
       case JObject(List(JField("$dt", JString(s)))) =>
-        format.dateFormat.parse(s).getOrElse(throw new MappingException("Can't parse "+ s + " to Date"))
+        losslessUTC.parse(s)
     },
     {
-      case x: Date => JObject(JField("$dt", JString(format.dateFormat.format(x))) :: Nil)
+      case x: Date =>
+        JObject(JField("$dt", JString(losslessUTC.format(x))) :: Nil)
     }
   ))
 


### PR DESCRIPTION
The timezone is hard coded as UTC. That really confusing. For my example(GMT+8), I read a date from database, `2014-04-08 10:00:00`, After render the json using 'yyyy-MM-dd HH:mm:ss' , it will become `2014-04-08 02:00:00`. this pr resolve the #60  issue
