### PR TITLE
Update for Scala 2.11

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
 
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.10.1" % "test"
 
-  lazy val specs = "org.specs2" %% "specs2"      % "2.3.10"  % "test"
+  lazy val specs = "org.specs2" %% "specs2"      % "2.3.11"  % "test"
 
   val jackson = Seq("com.fasterxml.jackson.core" % "jackson-databind" % "2.3.1")
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -54,7 +54,7 @@ object build extends Build {
   val json4sSettings = Defaults.defaultSettings ++ mavenCentralFrouFrou ++ Seq(
     organization := "org.json4s",
     scalaVersion := "2.10.0",
-    crossScalaVersions := Seq("2.10.0", "2.11.0-RC3"),
+    crossScalaVersions := Seq("2.10.0", "2.11.0"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-optimize", "-feature", "-Yinline-warnings", "-language:existentials", "-language:implicitConversions", "-language:higherKinds", "-language:reflectiveCalls", "-language:postfixOps"),
     version := "3.2.9-SNAPSHOT",
     javacOptions ++= Seq("-target", "1.6", "-source", "1.6"),


### PR DESCRIPTION
This pull request makes:
- Upgrade Scala version to 2.11.0 from 2.11.0-RC3
- Upgrade Specs2 to 2.3.11 from 2.3.10 which supports the newest version of Scalaz.
