### PR TITLE
#114 Don't produce invalid json when the first field is a JNothing

### DIFF
--- a/core/src/main/scala/org/json4s/json_writers.scala
+++ b/core/src/main/scala/org/json4s/json_writers.scala
@@ -536,6 +536,7 @@ private sealed trait StreamingJsonWriter[T <: JWriter] extends JsonWriter[T] {
     case JObject(flds) =>
       val obj = startObject()
       flds foreach {
+        case (k, v) if v == JNothing => this
         case (k, v) => obj.startField(k).addJValue(v)
       }
       obj.endObject()


### PR DESCRIPTION
Fix a bug which caused 
JObject(JField("foo", JNothing), JField("bar", JString("something")) :: Nil) 

to be rendered as {, "bar":"something"}
which is invalid.
