### PR TITLE
Adds UUIDSerializer to ext

### DIFF
--- a/ext/src/main/scala/org/json4s/ext/JavaTypesSerializers.scala
+++ b/ext/src/main/scala/org/json4s/ext/JavaTypesSerializers.scala
@@ -1,0 +1,36 @@
+/*
+* Copyright 2007-2011 WorldWide Conferencing, LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.json4s
+package ext
+
+import java.util.UUID
+import JsonDSL._
+
+object JavaTypesSerializers {
+	val all = List(UUIDSerializer)
+}
+
+case object UUIDSerializer extends CustomSerializer[UUID](format => (
+    {
+    case JString(s) => UUID.fromString(s)
+      case JNull => null
+    },
+    {
+      case x: UUID => JString(x.toString)
+    }
+  )
+)

--- a/tests/src/test/scala/org/json4s/ext/UUIDSerializerSpec.scala
+++ b/tests/src/test/scala/org/json4s/ext/UUIDSerializerSpec.scala
@@ -1,0 +1,50 @@
+/*
+* Copyright 2007-2011 WorldWide Conferencing, LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.json4s
+package ext
+
+import java.util.UUID
+import org.specs2.mutable.Specification
+
+
+object NativeUUIDSerializerSpec extends UUIDSerializerSpec("Native") {
+  val s: Serialization = native.Serialization
+}
+
+object JacksonUUIDSerializerSpec extends UUIDSerializerSpec("Jackson") {
+  val s: Serialization = jackson.Serialization
+}
+
+/**
+* System under specification for UUIDSerializer.
+*/
+abstract class UUIDSerializerSpec(mod: String) extends Specification {
+
+  def s: Serialization
+  implicit lazy val formats = s.formats(NoTypeHints) ++ JavaTypesSerializers.all
+
+  (mod + " UUIDSerializer Specification") should {
+    "Serialize UUID's" in {
+      val x = SubjectWithUUID(id=UUID.randomUUID())
+      val ser = s.write(x)
+      s.read[SubjectWithUUID](ser) must_== x
+    }
+  }
+}
+
+case class SubjectWithUUID(id:UUID)
+


### PR DESCRIPTION
Just a simple serialization extension for UUID. I noticed this one wasn't there and some people (like me) need it. 

I'm not sure if there should be other extended formats like java.sql.Date, but I named the file JavaTypesSerializers.scala proactively. A strategic rename is left as an exercise to the reader.
