### PR TITLE
Support Optional field validation

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -21,8 +21,10 @@ import java.math.{BigDecimal => JavaBigDecimal}
 import java.util.Date
 import java.sql.Timestamp
 import reflect._
+import scala.util.{Try, Failure, Success}
 import scala.reflect.Manifest
 import scala.collection.JavaConverters._
+import scala.Option
 
 
 
@@ -320,6 +322,12 @@ object Extraction {
     }
   }
 
+  private def throwOptionParseErrors[A](t: Try[A]): Option[A] = t match {
+    case Success(v) => Some(v)
+    case Failure(e: MappingException) => throw e
+    case Failure(e: Exception) => throw new MappingException("unknown error", e)
+  }
+
   def extract(json: JValue, scalaType: ScalaType)(implicit formats: Formats): Any = {
     if (scalaType.isEither) {
       import scala.util.control.Exception.allCatch
@@ -329,7 +337,15 @@ object Extraction {
         Right(extract(json, scalaType.typeArgs(1)))
       })).getOrElse(fail("Expected value but got " + json))
     } else if (scalaType.isOption) {
-      customOrElse(scalaType, json)(_.toOption flatMap (j => Option(extract(j, scalaType.typeArgs.head))))
+      val res = Try(customOrElse(scalaType, json){jval: JValue => extract(jval, scalaType.typeArgs.head)})
+      if (formats.noneForInvalidOptions) {
+        if (json == JNothing || json == JNull)
+          None
+        else
+          res.toOption
+      } else {
+        throwOptionParseErrors(res)
+      }
     } else if (scalaType.isMap) {
       json match {
         case JObject(xs) => {
@@ -457,7 +473,7 @@ object Extraction {
           else x
         } catch {
           case e @ MappingException(msg, _) =>
-            if (descr.isOptional) defv(None) else fail("No usable value for " + descr.name + "\n" + msg, e)
+            if (descr.isOptional && formats.noneForInvalidOptions) defv(None) else fail("No usable value for " + descr.name + "\n" + msg, e)
         }
       }
     }

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -48,6 +48,7 @@ trait Formats { self: Formats =>
   def wantsBigDecimal: Boolean = false
   def primitives: Set[Type] = Set(classOf[JValue], classOf[JObject], classOf[JArray])
   def companions: List[(Class[_], AnyRef)] = Nil
+  def noneForInvalidOptions: Boolean = true
 
   /**
    * The name of the field in JSON where type hints are added (jsonClass by default)
@@ -70,6 +71,7 @@ trait Formats { self: Formats =>
     override val wantsBigDecimal: Boolean = true
     override val primitives: Set[Type] = self.primitives
     override val companions: List[(Class[_], AnyRef)] = self.companions
+    override val noneForInvalidOptions: Boolean = self.noneForInvalidOptions
   }
 
   def withDouble: Formats = new Formats {
@@ -83,6 +85,7 @@ trait Formats { self: Formats =>
     override val wantsBigDecimal: Boolean = false
     override val primitives: Set[Type] = self.primitives
     override val companions: List[(Class[_], AnyRef)] = self.companions
+    override val noneForInvalidOptions: Boolean = self.noneForInvalidOptions
   }
 
   def withCompanions(comps: (Class[_], AnyRef)*): Formats = {
@@ -97,7 +100,22 @@ trait Formats { self: Formats =>
       override val wantsBigDecimal: Boolean = self.wantsBigDecimal
       override val primitives: Set[Type] = self.primitives
       override val companions: List[(Class[_], AnyRef)] = comps.toList ::: self.companions
+      override val noneForInvalidOptions: Boolean = self.noneForInvalidOptions
     }
+  }
+
+  def withOptionParseExceptionsThrown: Formats = new Formats {
+    val dateFormat: DateFormat = self.dateFormat
+    override val typeHintFieldName: String = self.typeHintFieldName
+    override val parameterNameReader: reflect.ParameterNameReader = self.parameterNameReader
+    override val typeHints: TypeHints = self.typeHints
+    override val customSerializers: List[Serializer[_]] = self.customSerializers
+    override val customKeySerializers: List[KeySerializer[_]] = self.customKeySerializers
+    override val fieldSerializers: List[(Class[_], FieldSerializer[_])] = self.fieldSerializers
+    override val wantsBigDecimal: Boolean = self.wantsBigDecimal
+    override val primitives: Set[Type] = self.primitives
+    override val companions: List[(Class[_], AnyRef)] = self.companions
+    override val noneForInvalidOptions: Boolean = false
   }
 
   /**
@@ -114,6 +132,7 @@ trait Formats { self: Formats =>
     override val wantsBigDecimal: Boolean = self.wantsBigDecimal
     override val primitives: Set[Type] = self.primitives
     override val companions: List[(Class[_], AnyRef)] = self.companions
+    override val noneForInvalidOptions: Boolean = self.noneForInvalidOptions
   }
 
   /**
@@ -129,6 +148,7 @@ trait Formats { self: Formats =>
     override val wantsBigDecimal: Boolean = self.wantsBigDecimal
     override val primitives: Set[Type] = self.primitives
     override val companions: List[(Class[_], AnyRef)] = self.companions
+    override val noneForInvalidOptions: Boolean = self.noneForInvalidOptions
   }
 
   /**
@@ -145,6 +165,7 @@ trait Formats { self: Formats =>
     override val wantsBigDecimal: Boolean = self.wantsBigDecimal
     override val primitives: Set[Type] = self.primitives
     override val companions: List[(Class[_], AnyRef)] = self.companions
+    override val noneForInvalidOptions: Boolean = self.noneForInvalidOptions
   }
 
   /**
@@ -174,6 +195,7 @@ trait Formats { self: Formats =>
     override val wantsBigDecimal: Boolean = self.wantsBigDecimal
     override val primitives: Set[Type] = self.primitives
     override val companions: List[(Class[_], AnyRef)] = self.companions
+    override val noneForInvalidOptions: Boolean = self.noneForInvalidOptions
   }
 
   private[json4s] def fieldSerializer(clazz: Class[_]): Option[FieldSerializer[_]] = {
@@ -359,6 +381,7 @@ trait Formats { self: Formats =>
     override val wantsBigDecimal: Boolean = false
     override val primitives: Set[Type] = Set(classOf[JValue], classOf[JObject], classOf[JArray])
     override val companions: List[(Class[_], AnyRef)] = Nil
+    override val noneForInvalidOptions: Boolean = true
 
     val dateFormat: DateFormat = new DateFormat {
       def parse(s: String) = try {

--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -229,6 +229,11 @@ abstract class ExtractionExamples[T](mod: String) extends Specification with Jso
     "Complex nested non-polymorphic collections extraction example" in {
       parse("""{"a":[{"b":"c"}]}""").extract[Map[String, List[Map[String, String]]]] must_== Map("a" -> List(Map("b" -> "c")))
     }
+
+    "Optional field extraction should throw a MappingException when noneForInvalidOptions is set to false" in {
+      val formatsWithOptionValidation = formats.withOptionParseExceptionsThrown
+      parse("""{"date":"Not a date"}""").extract[DateBox](formatsWithOptionValidation, Manifest.classType(classOf[DateBox])) must throwA(MappingException("No usable value for date\nInvalid date 'Not a date'", null))
+    }
   }
 
   val testJson =
@@ -364,3 +369,4 @@ case class MultipleConstructors(name: String, age: Int, size: Option[String]) {
 
 case class ClassWithJSON(name: String, message: JValue)
 
+case class DateBox(date: Option[Date])


### PR DESCRIPTION
Support throwing an exception when parsing a document that provides a key for an Option[T], but the value can't be converted to a T. It's useful in cases where if a value was provided it must be there, or the parse operation should not complete e.g. for web request bodies.  

a la https://github.com/json4s/json4s/issues/150

I think `withOptionParseExceptionsThrown` is a bit of a clunky name though. 
