### PR TITLE
Fix ScalaDoc example for MonadicJValue::mapField

### DIFF
--- a/core/src/main/scala/org/json4s/MonadicJValue.scala
+++ b/core/src/main/scala/org/json4s/MonadicJValue.scala
@@ -144,7 +144,7 @@ class MonadicJValue(jv: JValue) {
    * to each field in JSON.
    * <p>
    * Example:<pre>
-   * JObject(("age", JInt(10)) :: Nil) map {
+   * JObject(("age", JInt(10)) :: Nil) mapField {
    *   case ("age", JInt(x)) => ("age", JInt(x+1))
    *   case x => x
    * }


### PR DESCRIPTION
Currently doc for `mapField` uses `map` in example.
