### PR TITLE
Adds support for serializing/deserializing infinity floats and doubles

### DIFF
--- a/tests/src/test/scala/org/json4s/native/SerializationBugs.scala
+++ b/tests/src/test/scala/org/json4s/native/SerializationBugs.scala
@@ -204,6 +204,34 @@ object SerializationBugs extends Specification {
     val ser = swrite(mutable.Map("f" -> 1))
     ser must_== """{"f":1}"""
   }
+
+  "PositiveInfinity Float can be serialized" in {
+    val expected = SingleValue(Float.PositiveInfinity)
+    val serialized = native.Serialization.write(expected)
+    val deserialized = read[SingleValue[Float]](serialized)
+    expected.value must_== deserialized.value
+  }
+
+  "NegativeInfinity Float can be serialized" in {
+    val expected = SingleValue(Float.NegativeInfinity)
+    val serialized = native.Serialization.write(expected)
+    val deserialized = read[SingleValue[Float]](serialized)
+    expected.value must_== deserialized.value
+  }
+
+  "PositiveInfinity Double can be serialized" in {
+    val expected = SingleValue(Double.PositiveInfinity)
+    val serialized = native.Serialization.write(expected)
+    val deserialized = read[SingleValue[Double]](serialized)
+    expected.value must_== deserialized.value
+  }
+
+  "NegativeInfinity Double can be serialized" in {
+    val expected = SingleValue(Double.NegativeInfinity)
+    val serialized = native.Serialization.write(expected)
+    val deserialized = read[SingleValue[Double]](serialized)
+    expected.value must_== deserialized.value
+  }
 }
 
 case class Eith(x: Either[String, Int])
@@ -247,4 +275,3 @@ object Zot {
     case class Foo(s: String)
   }
 }
-


### PR DESCRIPTION
Currently Double and Float infinity values are serialized as `Infinity`, which is illegal according to the json specification. This causes any deserialization to blow up. 
This change explicitly serializes infinity values to a preset large value which is always deserialized as Infinity.
