### PR TITLE
Support for java.math.BigDecimal serialization

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -233,6 +233,7 @@ object Extraction {
     case x: java.lang.Byte => builder.byte(x.byteValue())
     case x: java.lang.Boolean => builder.boolean(x.booleanValue())
     case x: java.lang.Short => builder.short(x.shortValue())
+    case x: java.math.BigDecimal => builder.bigDecimal(x)
     case x: Date => builder.string(formats.dateFormat.format(x))
     case x: Symbol => builder.string(x.name)
     case _ => sys.error("not a primitive " + a.asInstanceOf[AnyRef].getClass)

--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -16,6 +16,7 @@
 
 package org.json4s
 
+import java.math.BigDecimal
 import java.util.Date
 import org.specs2.mutable.Specification
 import java.text.SimpleDateFormat
@@ -87,6 +88,12 @@ abstract class ExtractionExamples[T](mod: String) extends Specification with Jso
     "Primitive extraction example" in {
       val json = parse(primitives)
       json.extract[Primitives] must_== Primitives(124, 123L, 126.5, 127.5.floatValue, "128", 'symb, 125, 129.byteValue, true)
+    }
+
+    "BigDecimals extraction example" in {
+      val json = parse(bigdecimals)
+      json.extract[BigDecimalsScala] must_== BigDecimalsScala(scala.math.BigDecimal(100000000000L),
+                                                              scala.math.BigDecimal(200000000000L))
     }
 
     "Null extraction example" in {
@@ -309,6 +316,14 @@ abstract class ExtractionExamples[T](mod: String) extends Specification with Jso
 }
 """
 
+  val bigdecimals =
+    """
+{
+  "bds": 100000000000,
+  "bdj": 200000000000
+}
+    """
+
   val multiDimensionalArrays =
 """
 {
@@ -352,6 +367,9 @@ case class PersonWithAddresses(name: String, addresses: Map[String, Address])
 case class Name(name: String)
 
 case class Primitives(i: Int, l: Long, d: Double, f: Float, s: String, sym: Symbol, sh: Short, b: Byte, bool: Boolean)
+
+case class BigDecimals(bds: scala.math.BigDecimal, bdj:java.math.BigDecimal)
+case class BigDecimalsScala(bds: scala.math.BigDecimal, bdj:scala.math.BigDecimal)
 
 case class OChild(name: Option[String], age: Int, mother: Option[Parent], father: Option[Parent])
 case class Parent(name: String)

--- a/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
+++ b/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
@@ -43,6 +43,13 @@ object SerializationExamples extends Specification {
     read[Primitives](ser) must_== primitives
   }
 
+
+  "BigDecimals serialization example" in {
+    val bigdecimals = BigDecimals(BigDecimal(100000000000L),new java.math.BigDecimal(200000000000L))
+    val ser = swrite(bigdecimals)
+    read[BigDecimalsScala](ser) must_== BigDecimalsScala(BigDecimal(100000000000L),BigDecimal(200000000000L))
+  }
+
   "Multidimensional list example" in {
     val ints = Ints(List(List(1, 2), List(3), List(4, 5)))
     val ser = swrite(ints)


### PR DESCRIPTION
Both Scala and Java BigDecimal serialization support. Extraction is only to Scala BigDecimal
