### PR TITLE
Bump Scala lang minor versions (2.11.5, 2.10.4)

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -53,10 +53,10 @@ object build extends Build {
 
   val json4sSettings = mavenCentralFrouFrou ++ Seq(
     organization := "org.json4s",
-    scalaVersion := "2.10.0",
-    crossScalaVersions := Seq("2.10.0", "2.11.0"),
+    scalaVersion := "2.11.5",
+    crossScalaVersions := Seq("2.10.4", "2.11.5"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-optimize", "-feature", "-Yinline-warnings", "-language:existentials", "-language:implicitConversions", "-language:higherKinds", "-language:reflectiveCalls", "-language:postfixOps"),
-    version := "3.2.12-SNAPSHOT",
+    version := "3.3.0-SNAPSHOT",
     javacOptions ++= Seq("-target", "1.6", "-source", "1.6"),
     manifestSetting,
     publishSetting,


### PR DESCRIPTION
If there is no reason to stay at 2.10.0 and 2.11.0, it will be better to use latest minor version.