### PR TITLE
source-code compatible dependencies upgrade

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,43 +3,28 @@ import Keys._
 
 object Dependencies {
 
-  /* Steal from lift build */
-  def crossMapped(mappings: (String, String)*): CrossVersion =
-    CrossVersion.binaryMapped(Map(mappings: _*) orElse { case v => v })
-
-  def defaultOrMapped(default: String, alternatives: (String, String)*): String => String =
-    Map(alternatives: _*).withDefaultValue(default)
-
-  type ModuleMap = String => ModuleID
-
-  /* stop stealing */
-
-  lazy val scalaz_core = "org.scalaz" %% "scalaz-core" % "7.0.6"
-
-  val jodaTime = Seq("joda-time" % "joda-time" % "2.3", "org.joda" % "joda-convert" % "1.6")
-
-  val scalacheck = "org.scalacheck" %% "scalacheck" % "1.10.1" % "test"
-
-  lazy val specs = "org.specs2" %% "specs2"      % "2.3.11"  % "test"
-
-  val jackson = Seq("com.fasterxml.jackson.core" % "jackson-databind" % "2.3.1")
-
-  val jacksonScala = "com.fasterxml.jackson.module" % "jackson-module-scala" % "2.3.1" cross crossMapped("2.9.0" -> "2.9.1", "2.9.0-1" -> "2.9.1", "2.9.1-1" -> "2.9.1")
-
-  val paranamer = "com.thoughtworks.paranamer" % "paranamer" % "2.6"
-
-  val commonsCodec = "commons-codec"              % "commons-codec"      % "1.9"
-
-  val mockito = "org.mockito"                 % "mockito-all"              % "1.9.5"      % "test"
-
-  val liftCommon = "net.liftweb" %% "lift-common" % "2.5.1" cross crossMapped("2.9.3" -> "2.9.2")
+  lazy val jodaTime     = Seq(
+    "joda-time" % "joda-time"    % "2.6", 
+    "org.joda"  % "joda-convert" % "1.7"
+  )
+  lazy val jackson      = Seq(
+    // TODO 2.5 has breaking API changes
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.3.4"
+  )
+  lazy val jacksonScala = "com.fasterxml.jackson.module" %  "jackson-module-scala" % "2.3.1" 
+  lazy val liftCommon   = "net.liftweb"                  %% "lift-common"          % "2.5.1" 
+  // TODO: 7.1 has breaking API changes
+  lazy val scalaz_core  = "org.scalaz"                   %% "scalaz-core"          % "7.0.6"
+  lazy val paranamer    = "com.thoughtworks.paranamer"   %  "paranamer"            % "2.7"
+  lazy val commonsCodec = "commons-codec"                %  "commons-codec"        % "1.9"
+  // TODO: combination of specs2 2.4 and scalacheck 1.11 has breaking API changes
+  lazy val scalacheck   = "org.scalacheck"               %% "scalacheck"           % "1.10.1"    % "test"
+  lazy val specs        = "org.specs2"                   %% "specs2"               % "2.3.13"    % "test"
+  lazy val mockito      = "org.mockito"                  %  "mockito-all"          % "1.10.19"   % "test"
 
   def scalaXml(scalaVersion: String) = {
-    if(scalaVersion.startsWith("2.11"))
-      Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.3")
-    else
-      Nil
+    if (scalaVersion.startsWith("2.11")) Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.3")
+    else Nil
   }
 
-//  val scalaj_collection = "org.scalaj" %% "scalaj-collection" % "1.2" cross CVMappingAll
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -1,10 +1,8 @@
 import sbt._
 import Keys._
 import xml.Group
-//import sbtscalashim.Plugin._
 import sbtbuildinfo.Plugin._
 import com.typesafe.sbt.SbtStartScript
-
 
 object build extends Build {
   import Dependencies._
@@ -110,7 +108,7 @@ object build extends Build {
     settings = json4sSettings ++ Seq(libraryDependencies ++= jodaTime)
   ) dependsOn(native % "provided->compile;test->test")
 
-//
+  // TODO: remove this?
 //  lazy val nativeLift = Project(
 //    id = "json4s-native-lift",
 //    base = file("native-lift"),
@@ -122,12 +120,6 @@ object build extends Build {
     base = file("jackson"),
     settings = json4sSettings ++ Seq(libraryDependencies ++= jackson)
   ) dependsOn(core % "compile;test->test")
-//
-//  lazy val playSupport = Project(
-//    id = "json4s-play",
-//    base = file("play"),
-//    settings = json4sSettings ++ Seq(libraryDependencies ++= jackson)
-//  ) dependsOn(core % "compile;test->test")
 
   lazy val examples = Project(
      id = "json4s-examples",
@@ -143,13 +135,6 @@ object build extends Build {
     json4sExt,
     mongo)
 
-//
-//  lazy val jacksonExt = Project(
-//    id = "json4s-jackson-ext",
-//    base = file("jackson-ext"),
-//    settings = json4sSettings ++ Seq(libraryDependencies ++= jodaTime)
-//  ) dependsOn(jacksonSupport % "compile;test->test")
-//
   lazy val scalazExt = Project(
     id = "json4s-scalaz",
     base = file("scalaz"),
@@ -161,7 +146,7 @@ object build extends Build {
      base = file("mongo"),
      settings = json4sSettings ++ Seq(
        libraryDependencies ++= Seq(
-         "org.mongodb" % "mongo-java-driver" % "2.11.4"
+         "org.mongodb" % "mongo-java-driver" % "2.12.4"
       )
   )) dependsOn(core % "compile;test->test")
 


### PR DESCRIPTION
- upgrade minor versions of dependencies
- cleaning up build settings

#### Before

```
> dependencyUpdates
[info] No dependency updates found for json4s
[info] No dependency updates found for json4s-ast
[info] Found 1 dependency update for json4s-jackson
[info]   com.fasterxml.jackson.core:jackson-databind : 2.3.1 -> 2.3.4 -> 2.5.0
[info] Found 1 dependency update for json4s-core
[info]   com.thoughtworks.paranamer:paranamer : 2.6 -> 2.6.1 -> 2.7
[info] No dependency updates found for json4s-native
[info] No dependency updates found for json4s-scalap
[info] Found 1 dependency update for json4s-scalaz
[info]   org.scalaz:scalaz-core : 7.0.6 -> 7.1.0
[info] Found 1 dependency update for json4s-mongo
[info]   org.mongodb:mongo-java-driver : 2.11.4 -> 2.12.4
[info] Found 2 dependency updates for json4s-ext
[info]   joda-time:joda-time   : 2.3 -> 2.6
[info]   org.joda:joda-convert : 1.6 -> 1.7
[info] Found 3 dependency updates for json4s-tests
[info]   org.mockito:mockito-all:test   : 1.9.5            -> 1.10.19
[info]   org.scalacheck:scalacheck:test : 1.10.1           -> 1.12.1
[info]   org.specs2:specs2:test         : 2.3.11 -> 2.3.13 -> 2.4.15
```

#### After

```
> dependencyUpdates
[info] No dependency updates found for json4s
[info] No dependency updates found for json4s-mongo
[info] No dependency updates found for json4s-scalap
[info] No dependency updates found for json4s-ast
[info] No dependency updates found for json4s-native
[info] Found 2 dependency updates for json4s-tests
[info]   org.scalacheck:scalacheck:test : 1.10.1 -> 1.12.1
[info]   org.specs2:specs2:test         : 2.3.13 -> 2.4.15
[info] No dependency updates found for json4s-core
[info] Found 1 dependency update for json4s-jackson
[info]   com.fasterxml.jackson.core:jackson-databind : 2.3.4 -> 2.5.0
[info] No dependency updates found for json4s-ext
[info] Found 1 dependency update for json4s-scalaz
[info]   org.scalaz:scalaz-core : 7.0.6 -> 7.1.0
```