### PR TITLE
2.9.1 and 2.9.2 support removal (related to #201)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 scala:
-  - 2.9.1
-  - 2.9.2
+  # since version 3.2.12, we support only 2.9.3
   - 2.9.3
 sudo: false
 script: sbt ++$TRAVIS_SCALA_VERSION test

--- a/project/build.scala
+++ b/project/build.scala
@@ -55,7 +55,8 @@ object build extends Build {
   val json4sSettings = Defaults.defaultSettings ++ mavenCentralFrouFrou ++ Seq(
     organization := "org.json4s",
     scalaVersion := "2.9.3",
-    crossScalaVersions := Seq("2.9.1", "2.9.1-1", "2.9.2", "2.9.3"),
+    // NOTE: since version 3.2.12, we support only 2.9.3
+    crossScalaVersions := Seq("2.9.3"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-optimize"),
     version := "3.2.12-SNAPSHOT",
     javacOptions ++= Seq("-target", "1.6", "-source", "1.6"),


### PR DESCRIPTION
see also: https://github.com/json4s/json4s/issues/201
So we can drop 2.9.1 and 2.9.2 builds on Travis CI.