### PR TITLE
Fix for failed lazy val serialization

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -68,6 +68,30 @@ object Extraction {
     builder.result
   }
 
+  /** Load lazy val value
+    *
+    * This is a fix for failed lazy val serialization from FieldSerializer (see org.json4s.native.LazyValBugs test).
+    *
+    * We do this by finding the hidden lazy method which will have same name as the lazy val name
+    * but with suffix "$lzycompute" (for scala v2.10+), then invoke the method if found, and return the value.
+    *
+    * The "$lzycompute" method naming could be changed in future so this method must be adjusted if that happens.
+    *
+    * @param a Object to be serialized
+    * @param name Field name to be checked
+    * @param defaultValue Default value if lazy method is not found
+    * @return Value of invoked lazy method if found, else return the default value
+    */
+  def loadLazyValValue(a: Any, name: String, defaultValue: Any) = {
+    try {
+      val method = a.getClass.getDeclaredMethod(name + "$lzycompute")
+      method.setAccessible(true)
+      method.invoke(a)
+    } catch {
+      case e: Exception => defaultValue
+    }
+  }
+
   /** Decompose a case class into JSON.
    *
    * This is broken out to avoid calling builder.result when we return from recusion
@@ -102,10 +126,12 @@ object Extraction {
         val fieldVal = prop.get(any)
         val n = prop.name
         if (fs.isDefined) {
-          val ff = (fs.get.serializer orElse Map((n, fieldVal) -> Some((n, fieldVal))))((n, fieldVal))
+          val fieldSerializer = fs.get
+          val ff = (fieldSerializer.serializer orElse Map((n, fieldVal) -> Some((n, fieldVal))))((n, fieldVal))
           if (ff.isDefined) {
             val Some((nn, vv)) = ff
-            addField(nn, vv, obj)
+            val vvv = if (fieldSerializer.includeLazyVal) loadLazyValValue(a, nn, vv) else vv
+            addField(nn, vvv, obj)
           }
         } else if (ctorParams contains prop.name) addField(n, fieldVal, obj)
       }
@@ -431,7 +457,11 @@ object Extraction {
 
           fieldsToSet foreach { prop =>
             jsonSerializers get prop.name foreach { case (_, v) =>
-              prop.set(a, extract(v, prop.returnType))
+              val vv = extract(v, prop.returnType)
+              // If includeLazyVal is set, try to find and initialize lazy val.
+              // This is to prevent the extracted value to be overwritten by the lazy val initialization.
+              if (serializer.includeLazyVal) loadLazyValValue(a, prop.name, vv) else ()
+              prop.set(a, vv)
             }
           }
         }

--- a/core/src/main/scala/org/json4s/FieldSerializer.scala
+++ b/core/src/main/scala/org/json4s/FieldSerializer.scala
@@ -12,10 +12,13 @@ package org.json4s
  *   renameFrom("animalname", "name")
  * )
  * </pre>
+ *
+ * The third optional parameter "includeLazyVal" determines if serializer will serialize/deserialize lazy val fields or not.
  */
 case class FieldSerializer[A](
   serializer:   PartialFunction[(String, Any), Option[(String, Any)]] = Map(),
-  deserializer: PartialFunction[JField, JField] = Map()
+  deserializer: PartialFunction[JField, JField] = Map(),
+  includeLazyVal: Boolean = false
 )(implicit val mf: Manifest[A])
 
 object FieldSerializer {

--- a/tests/src/test/scala/org/json4s/native/LazyValBugs.scala
+++ b/tests/src/test/scala/org/json4s/native/LazyValBugs.scala
@@ -1,0 +1,129 @@
+package org.json4s.native
+
+import org.json4s.{FieldSerializer, DefaultFormats}
+import org.json4s.native.Serialization.{read, write}
+import org.specs2.mutable.Specification
+
+class MovieNode(val id: String, val title: String)
+
+class ActorNode(val id: String, val name: String) {
+  val normalMovie: MovieNode = new MovieNode("M1", "Die Hard")
+  lazy val lazyMovie: MovieNode = new MovieNode("M2", "Armageddon")
+  lazy val lazyMovies: List[MovieNode] = List(new MovieNode("M3", "Sixth Sense"), new MovieNode("M4", "Unbreakable"))
+  lazy val rating: Int = 3
+  lazy val isBald: Boolean = true
+}
+
+/** Test of a fix for failed lazy val serialization from FieldSerializer
+  * where the serialized lazy val will get default value result (null, 0, false, etc) instead of the real value.
+  *
+  */
+class LazyValBugs extends Specification {
+
+  "LazyValBugs Test" should {
+
+    "Serialize lazy val to json" in {
+      implicit val formats = DefaultFormats + FieldSerializer[ActorNode](includeLazyVal = true)
+
+      val actorNode = new ActorNode("A1", "Bruce Willis")
+      val res = write(actorNode)
+
+      res.contains(""""normalMovie":null""") must beFalse
+      res.contains(""""lazyMovie":null""") must beFalse
+      res.contains(""""lazyMovies":null""") must beFalse
+      res.contains(""""rating":0""") must beFalse
+      res.contains(""""isBald":false""") must beFalse
+    }
+
+    "Don't serialize lazy val to json if includeLazyVal is not set in FieldSerializer" in {
+      implicit val formats = DefaultFormats + FieldSerializer[ActorNode]()
+
+      val actorNode = new ActorNode("A1", "Bruce Willis")
+      val res = write(actorNode)
+
+      res.contains(""""normalMovie":null""") must beFalse
+      res.contains(""""lazyMovie":null""") must beTrue
+      res.contains(""""lazyMovies":null""") must beTrue
+      res.contains(""""rating":0""") must beTrue
+      res.contains(""""isBald":false""") must beTrue
+    }
+
+    val jsonStr =
+      s"""
+         |{
+         |  "id": "A2",
+         |  "name": "Tom Hanks",
+         |  "rating": 5,
+         |  "isBald": false,
+         |  "normalMovie":
+         |  {
+         |    "id": "M13",
+         |    "title": "Apollo 13"
+         |  },
+         |  "lazyMovie":
+         |  {
+         |    "id": "M5",
+         |    "title": "Forrest Gump"
+         |  },
+         |  "lazyMovies": [
+         |  {
+         |    "id": "M6",
+         |    "title": "Cast Away"
+         |  },
+         |  {
+         |    "id": "M7",
+         |    "title": "You've Got Mail"
+         |  },
+         |  {
+         |    "id": "M8",
+         |    "title": "The Da Vinci Code"
+         |  }
+         |  ]
+         |}
+         """.stripMargin
+
+    "Deserialize lazy val value from parsed json" in {
+      implicit val formats = DefaultFormats + FieldSerializer[ActorNode](includeLazyVal = true)
+
+      val actorNode = read[ActorNode](jsonStr)
+
+      actorNode.id === "A2"
+      actorNode.name === "Tom Hanks"
+      actorNode.normalMovie.id === "M13"
+      actorNode.normalMovie.title === "Apollo 13"
+      actorNode.lazyMovie.id === "M5"
+      actorNode.lazyMovie.title === "Forrest Gump"
+      actorNode.lazyMovies must have size 3
+      for (movie <- actorNode.lazyMovies) {
+        if (movie.id == "M6") movie.title === "Cast Away"
+        else if (movie.id == "M7") movie.title === "You've Got Mail"
+        else if (movie.id == "M8") movie.title === "The Da Vinci Code"
+        else failure("Invalid movie id found: " + movie.id)
+      }
+      actorNode.rating === 5
+      actorNode.isBald === false
+    }
+
+    "Don't deserialize lazy val from parsed json if includeLazyVal is not set in FieldSerializer" in {
+      implicit val formats = DefaultFormats + FieldSerializer[ActorNode]()
+
+      val actorNode = read[ActorNode](jsonStr)
+
+      actorNode.id === "A2"
+      actorNode.name === "Tom Hanks"
+      actorNode.normalMovie.id === "M13"
+      actorNode.normalMovie.title === "Apollo 13"
+      actorNode.lazyMovie.id === "M2"
+      actorNode.lazyMovie.title === "Armageddon"
+      actorNode.lazyMovies must have size 2
+      for (movie <- actorNode.lazyMovies) {
+        if (movie.id == "M3") movie.title === "Sixth Sense"
+        else if (movie.id == "M4") movie.title === "Unbreakable"
+        else failure("Invalid movie id found: " + movie.id)
+      }
+      actorNode.rating === 3
+      actorNode.isBald === true
+    }
+  }
+
+}


### PR DESCRIPTION
Problem description can be read at [here][1].

Since I really need the lazy val serialization so I decided to solve the problem by myself. 

I modified the Extraction.scala to make the serializer invokes the hidden lazy val method. I also added new parameter `includeLazyVal` to the FieldSerializer so user can choose to enable the lazy val serialization or not.

    implicit val formats = DefaultFormats + FieldSerializer[ActorNode](includeLazyVal = true)

The test can be seen at [here][2].

However this fix only works for scala v2.10+ since the compiler generates "$lzycompute" method underhood for the lazy val fields so the lazy val method can be detected. It's possible to make it work for scala v2.9 and below but it will incur unnecessary overhead, as at those scala versions the compiler generates same lazy val method name as the lazy val field name, so there is no way to detect the lazy val method, and thus the non-lazy val methods will get invoked as well in the process. But if anyone want it to support for v2.9 as well, I can add the changes.


  [1]: https://github.com/json4s/json4s/issues/111
  [2]: https://github.com/sdiwu/json4s/blob/3.3/tests/src/test/scala/org/json4s/native/LazyValBugs.scala