### PR TITLE
Fixing example in README.md to be valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Json AST can be queried using XPath like functions. Following REPL session shows
         "age": 35,
         "spouse": {
           "person": {
-            "name": "Marilyn"
+            "name": "Marilyn",
             "age": 33
           }
         }


### PR DESCRIPTION
Very minor issue in that, without the comma, the example is not valid JSON