### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/core/src/main/scala/org/json4s/Xml.scala
+++ b/core/src/main/scala/org/json4s/Xml.scala
@@ -186,7 +186,7 @@ object Xml {
     }
   }
 
-  private[json4s] class XmlNode(name: String, children: Seq[Node]) extends Elem(null, name, xml.Null, TopScope, children :_*)
+  private[json4s] class XmlNode(name: String, children: Seq[Node]) extends Elem(null, name, xml.Null, TopScope, children.isEmpty, children :_*)
 
-  private[json4s] class XmlElem(name: String, value: String) extends Elem(null, name, xml.Null, TopScope, Text(value))
+  private[json4s] class XmlElem(name: String, value: String) extends Elem(null, name, xml.Null, TopScope, false, Text(value))
 }

--- a/examples/src/main/scala/org/json4s/examples/MongoExamples.scala
+++ b/examples/src/main/scala/org/json4s/examples/MongoExamples.scala
@@ -17,8 +17,9 @@ object MongoExamples extends App with jackson.JsonMethods {
   }
 
 
-  val mongo = com.mongodb.Mongo.connect(new DBAddress("127.0.0.1", "json4s_examples"))
-  val coll = mongo.getCollection("swagger_data")
+  val mongo = new MongoClient("127.0.0.1")
+  val db = mongo.getDB("json4s_examples")
+  val coll = db.getCollection("swagger_data")
 
   val f = for {
     listing <- Http(url("http://petstore.swagger.wordnik.com/api/api-docs") OK read.Json)

--- a/examples/src/main/scala/org/json4s/examples/Swagger.scala
+++ b/examples/src/main/scala/org/json4s/examples/Swagger.scala
@@ -99,7 +99,7 @@ object Api {
       def parse(s: String) = try {
         Option(Iso8601Date.parseDateTime(s).toDate)
       } catch {
-        case _ ⇒ None
+        case scala.util.control.NonFatal(_) ⇒ None
       }
     }
   } ++ Seq(

--- a/ext/src/main/scala/org/json4s/ext/JodaTimeSerializers.scala
+++ b/ext/src/main/scala/org/json4s/ext/JodaTimeSerializers.scala
@@ -72,6 +72,8 @@ case object DateTimeSerializer extends CustomSerializer[DateTime](format => (
   }
 ))
 
+// see: http://www.joda.org/joda-time/apidocs/org/joda/time/DateMidnight.html
+@deprecated("The time of midnight does not exist in some time zones where the daylight saving time forward shift skips the midnight hour. Use LocalDate to represent a date without a time zone. Or use DateTime to represent a full date and time, perhaps using DateTime.withTimeAtStartOfDay() to get an instant at the start of a day. (http://www.joda.org/joda-time/apidocs/org/joda/time/DateMidnight.html)", since = "3.3.0")
 case object DateMidnightSerializer extends CustomSerializer[DateMidnight](format => (
   {
     case JString(s) => new DateMidnight(DateParser.parse(s, format))

--- a/native/src/main/scala/org/json4s/native/JsonParser.scala
+++ b/native/src/main/scala/org/json4s/native/JsonParser.scala
@@ -129,7 +129,7 @@ object JsonParser {
     def closeBlock(v: Any) {
       @inline def toJValue(x: Any) = x match {
         case json: JValue => json
-        case _ => p.fail(s"unexpected field $x")
+        case scala.util.control.NonFatal(_) => p.fail(s"unexpected field $x")
       }
 
       vals.peekOption match {
@@ -214,7 +214,7 @@ object JsonParser {
           ParserUtil.unquote(buf)
         } catch {
           case p: ParseException => throw p
-          case _ => fail("unexpected string end")
+          case scala.util.control.NonFatal(_) => fail("unexpected string end")
         }
 
       def parseValue(first: Char) = {


### PR DESCRIPTION
This pull request fixes some deprecation warnings. The following warnings still remains (reflection and scala.text.* things).

```
[info] Compiling 22 Scala sources to /Users/seratch/github/json4s/core/target/scala-2.11/classes...
[warn] /Users/seratch/github/json4s/core/src/main/scala/org/json4s/reflect/descriptors.scala:144: method <:< in trait ClassManifestDeprecatedApis is deprecated: Use scala.reflect.runtime.universe.TypeTag for subtype checking instead
[warn]   def <:<(that: ScalaType): Boolean = manifest <:< that.manifest
[warn]                                                ^
[warn] /Users/seratch/github/json4s/core/src/main/scala/org/json4s/reflect/descriptors.scala:145: method >:> in trait ClassManifestDeprecatedApis is deprecated: Use scala.reflect.runtime.universe.TypeTag for subtype checking instead
[warn]   def >:>(that: ScalaType): Boolean = manifest >:> that.manifest
[warn]                                                ^
[warn] two warnings found
[info] Compiling 4 Scala sources to /Users/seratch/github/json4s/mongo/target/scala-2.11/classes...
[info] Compiling 10 Scala sources to /Users/seratch/github/json4s/jackson/target/scala-2.11/classes...
[info] Compiling 6 Scala sources to /Users/seratch/github/json4s/native/target/scala-2.11/classes...
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/Printer.scala:25: match may not be exhaustive.
[warn] It would fail on the following input: List((x: scala.text.Document forSome x not in (DocBreak, DocNil, scala.text.DocCons, scala.text.DocGroup, scala.text.DocNest, scala.text.DocText)))
[warn]     def layout(docs: List[Document]): Unit = docs match {
[warn]                                              ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:8: class Document in package text is deprecated: This class will be removed.
[warn] trait JsonMethods extends org.json4s.JsonMethods[Document] {
[warn]                                      ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:28: class Document in package text is deprecated: This class will be removed.
[warn]   def render(value: JValue)(implicit formats: Formats = DefaultFormats): Document =
[warn]                                                                          ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:30: object Document in package text is deprecated: This object will be removed.
[warn]       case null          => text("null")
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:31: object Document in package text is deprecated: This object will be removed.
[warn]       case JBool(true)   => text("true")
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:32: object Document in package text is deprecated: This object will be removed.
[warn]       case JBool(false)  => text("false")
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:33: object Document in package text is deprecated: This object will be removed.
[warn]       case JDouble(n)    => text(n.toString)
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:34: object Document in package text is deprecated: This object will be removed.
[warn]       case JDecimal(n)   => text(n.toString)
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:35: object Document in package text is deprecated: This object will be removed.
[warn]       case JInt(n)       => text(n.toString)
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:36: object Document in package text is deprecated: This object will be removed.
[warn]       case JNull         => text("null")
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:38: object Document in package text is deprecated: This object will be removed.
[warn]       case JString(null) => text("null")
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:39: object Document in package text is deprecated: This object will be removed.
[warn]       case JString(s)    => text("\""+ParserUtil.quote(s)+"\"")
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:40: object Document in package text is deprecated: This object will be removed.
[warn]       case JArray(arr)   => text("[") :: series(trimArr(arr).map(render)) :: text("]")
[warn]                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:40: object Document in package text is deprecated: This object will be removed.
[warn]       case JArray(arr)   => text("[") :: series(trimArr(arr).map(render)) :: text("]")
[warn]                                                                              ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:42: object Document in package text is deprecated: This object will be removed.
[warn]         val nested = break :: fields(trimObj(obj).map({case (n,v) => text("\""+ParserUtil.quote(n)+"\":") :: render(v)}))
[warn]                      ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:42: object Document in package text is deprecated: This object will be removed.
[warn]         val nested = break :: fields(trimObj(obj).map({case (n,v) => text("\""+ParserUtil.quote(n)+"\":") :: render(v)}))
[warn]                                                                      ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:43: object Document in package text is deprecated: This object will be removed.
[warn]         text("{") :: nest(2, nested) :: break :: text("}")
[warn]         ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:43: object Document in package text is deprecated: This object will be removed.
[warn]         text("{") :: nest(2, nested) :: break :: text("}")
[warn]                      ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:43: object Document in package text is deprecated: This object will be removed.
[warn]         text("{") :: nest(2, nested) :: break :: text("}")
[warn]                                         ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:43: object Document in package text is deprecated: This object will be removed.
[warn]         text("{") :: nest(2, nested) :: break :: text("}")
[warn]                                                  ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:48: class Document in package text is deprecated: This class will be removed.
[warn]   private def series(docs: List[Document]) = punctuate(text(","), docs)
[warn]                            ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:48: object Document in package text is deprecated: This object will be removed.
[warn]   private def series(docs: List[Document]) = punctuate(text(","), docs)
[warn]                                                        ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:49: class Document in package text is deprecated: This class will be removed.
[warn]   private def fields(docs: List[Document]) = punctuate(text(",") :: break, docs)
[warn]                            ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:49: object Document in package text is deprecated: This object will be removed.
[warn]   private def fields(docs: List[Document]) = punctuate(text(",") :: break, docs)
[warn]                                                        ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:49: object Document in package text is deprecated: This object will be removed.
[warn]   private def fields(docs: List[Document]) = punctuate(text(",") :: break, docs)
[warn]                                                                     ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:51: class Document in package text is deprecated: This class will be removed.
[warn]   private def punctuate(p: Document, docs: List[Document]): Document =
[warn]                            ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:51: class Document in package text is deprecated: This class will be removed.
[warn]   private def punctuate(p: Document, docs: List[Document]): Document =
[warn]                                            ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:51: class Document in package text is deprecated: This class will be removed.
[warn]   private def punctuate(p: Document, docs: List[Document]): Document =
[warn]                                                             ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:52: object Document in package text is deprecated: This object will be removed.
[warn]     if (docs.length == 0) empty
[warn]                           ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:56: class Document in package text is deprecated: This class will be removed.
[warn]   def compact(d: Document): String = Printer.compact(d)
[warn]                  ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/JsonMethods.scala:57: class Document in package text is deprecated: This class will be removed.
[warn]   def pretty(d: Document): String = Printer.pretty(d)
[warn]                 ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/Printer.scala:20: class Document in package text is deprecated: This class will be removed.
[warn]   def compact(d: Document): String = compact(d, new StringWriter).toString
[warn]                  ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/Printer.scala:24: class Document in package text is deprecated: This class will be removed.
[warn]   def compact[A <: Writer](d: Document, out: A): A = {
[warn]                               ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/Printer.scala:25: class Document in package text is deprecated: This class will be removed.
[warn]     def layout(docs: List[Document]): Unit = docs match {
[warn]                      ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/Printer.scala:29: object DocBreak in package text is deprecated: This object will be removed.
[warn]       case DocBreak :: rs        => layout(rs)
[warn]            ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/Printer.scala:32: object DocNil in package text is deprecated: This object will be removed.
[warn]       case DocNil :: rs          => layout(rs)
[warn]            ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/Printer.scala:42: class Document in package text is deprecated: This class will be removed.
[warn]   def pretty(d: Document): String = pretty(d, new StringWriter).toString
[warn]                 ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/Printer.scala:46: class Document in package text is deprecated: This class will be removed.
[warn]   def pretty[A <: Writer](d: Document, out: A): A = {
[warn]                              ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/package.scala:12: class Document in package text is deprecated: This class will be removed.
[warn]   def renderJValue(value: JValue)(implicit formats: Formats = DefaultFormats): Document =
[warn]                                                                                ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/package.scala:15: class Document in package text is deprecated: This class will be removed.
[warn]   def compactJson(d: Document): String = JsonMethods.compact(d)
[warn]                      ^
[warn] /Users/seratch/github/json4s/native/src/main/scala/org/json4s/native/package.scala:17: class Document in package text is deprecated: This class will be removed.
[warn]   def prettyJson(d: Document): String = JsonMethods.pretty(d)
[warn]                     ^
[warn] 41 warnings found
[info] Compiling 3 Scala sources to /Users/seratch/github/json4s/ext/target/scala-2.11/classes...
[info] Compiling 6 Scala sources to /Users/seratch/github/json4s/scalaz/target/scala-2.11/classes...
[warn] /Users/seratch/github/json4s/ext/src/main/scala/org/json4s/ext/JodaTimeSerializers.scala:26: object DateMidnightSerializer in package ext is deprecated: The time of midnight does not exist in some time zones where the daylight saving time forward shift skips the midnight hour. Use LocalDate to represent a date without a time zone. Or use DateTime to represent a full date and time, perhaps using DateTime.withTimeAtStartOfDay() to get an instant at the start of a day. (http://www.joda.org/joda-time/apidocs/org/joda/time/DateMidnight.html)
[warn]                  DateMidnightSerializer, IntervalSerializer(), LocalDateSerializer(),
[warn]                  ^
[warn] one warning found
[info] Compiling 4 Scala sources to /Users/seratch/github/json4s/benchmark/target/scala-2.11/classes...
[info] Compiling 6 Scala sources to /Users/seratch/github/json4s/examples/target/scala-2.11/classes...
[success] Total time: 34 s, completed May 16, 2015 10:31:14 AM
>
```
