### PR TITLE
Added support for java8 time

### DIFF
--- a/ext/src/main/scala/org/json4s/ext/JavaTimeSerializers.scala
+++ b/ext/src/main/scala/org/json4s/ext/JavaTimeSerializers.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2006-2010 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.json4s.ext
+
+import java.time._
+import java.util.Date
+
+import org.json4s._
+import org.json4s.JsonAST.{JNull, JString}
+import org.json4s.ext.JavaDateConverters._
+
+
+object JavaTimeSerializers {
+  def all = List(
+    JDurationSerializer,
+    JInstantSerializer,
+    JYearSerializer,
+    JLocalDateTimeSerializer,
+    JLocalDateSerializer(),
+    JLocalTimeSerializer(),
+    JPeriodSerializer(),
+    JYearMonthSerializer(),
+    JMonthDaySerializer()
+  )
+}
+
+case object JDurationSerializer extends CustomSerializer[Duration]( format => (
+  {
+    case JInt(d) => Duration.ofMillis(d.toLong)
+    case JNull => null
+  },
+  {
+    case d: Duration => JInt(d.toMillis)
+  }
+))
+
+case object JInstantSerializer extends CustomSerializer[Instant]( format => (
+  {
+    case JInt(d) => Instant.ofEpochMilli(d.toLong)
+    case JNull => null
+  },
+  {
+    case i: Instant => JInt(i.toEpochMilli)
+  }
+))
+
+case object JYearSerializer extends CustomSerializer[Year](format => (
+  {
+    case JInt(n) => Year.of(n.toInt)
+    case JNull => null
+  },
+  {
+    case y: Year => JInt(y.getValue)
+  }
+))
+
+case object JLocalDateTimeSerializer extends CustomSerializer[LocalDateTime](format => (
+  {
+    case JString(s) => 
+      new Date(DateParser.parse(s, format)).toLocalDateTime
+    case JNull => null
+  },
+  {
+    case ldt: LocalDateTime => 
+      JString(format.dateFormat.format(ldt.toDate))
+  }
+))
+
+private[ext] case class _JLocalDate(year: Int, month: Int, day: Int)
+object JLocalDateSerializer {
+  def apply() = new ClassSerializer(new ClassType[LocalDate, _JLocalDate]() {
+    def unwrap(ld: _JLocalDate)(implicit format: Formats) =
+      LocalDate.of(ld.year, ld.month, ld.day)
+    def wrap(ld: LocalDate)(implicit format: Formats) =
+      _JLocalDate(ld.getYear, ld.getMonthValue, ld.getDayOfMonth)
+  })
+}
+
+private[ext] case class _JLocalTime(hour: Int, minute: Int, second: Int, nanoOfSecond: Int)
+object JLocalTimeSerializer {
+  def apply() = new ClassSerializer(new ClassType[LocalTime, _JLocalTime]() {
+    def unwrap(lt: _JLocalTime)(implicit format: Formats) =
+      LocalTime.of(lt.hour, lt.minute, lt.second, lt.nanoOfSecond)
+    def wrap(lt: LocalTime)(implicit format: Formats) =
+      _JLocalTime(lt.getHour, lt.getMinute, lt.getSecond, lt.getNano)
+  })
+}
+
+private[ext] case class _JPeriod(years: Int, months: Int, days: Int)
+object JPeriodSerializer {
+  def apply() = new ClassSerializer(new ClassType[Period, _JPeriod]() {
+    def unwrap(p: _JPeriod)(implicit format: Formats) = Period.of(p.years, p.months, p.days)
+    def wrap(p: Period)(implicit format: Formats) = _JPeriod(p.getYears, p.getMonths, p.getDays)
+  })
+}
+
+private[ext] case class _JYearMonth(year: Int, month: Int)
+object JYearMonthSerializer {
+  def apply() = new ClassSerializer(new ClassType[YearMonth, _JYearMonth]() {
+    def unwrap(ym: _JYearMonth)(implicit format: Formats) = YearMonth.of(ym.year, ym.month)
+    def wrap(ym: YearMonth)(implicit format: Formats) = _JYearMonth(ym.getYear, ym.getMonthValue)
+  })
+}
+
+private[ext] case class _JMonthDay(month: Int, dayOfMonth: Int)
+object JMonthDaySerializer {
+  def apply() = new ClassSerializer(new ClassType[MonthDay, _JMonthDay]() {
+    def unwrap(md: _JMonthDay)(implicit format: Formats) = MonthDay.of(md.month, md.dayOfMonth)
+    def wrap(md: MonthDay)(implicit format: Formats) = _JMonthDay(md.getMonthValue, md.getDayOfMonth)
+  })
+}
+
+object JavaDateConverters {
+
+  implicit class ExtendedLocalDateTime(val ldt: LocalDateTime) extends AnyVal {
+    def toDate: Date = {
+      val instant = ldt.atZone(ZoneId.systemDefault).toInstant
+      Date.from(instant)
+    }
+  }
+  
+  implicit class ExtendedDate(val d: Date) extends AnyVal {
+    def toLocalDateTime: LocalDateTime =
+      LocalDateTime.ofInstant(d.toInstant, ZoneId.systemDefault)
+  }
+}
+

--- a/ext/src/main/scala/org/json4s/ext/commons.scala
+++ b/ext/src/main/scala/org/json4s/ext/commons.scala
@@ -1,0 +1,31 @@
+package org.json4s.ext
+
+import org.json4s._
+import org.json4s.reflect.TypeInfo
+
+
+object DateParser {
+  def parse(s: String, format: Formats) =
+    format.dateFormat.parse(s).map(_.getTime).getOrElse(throw new MappingException(s"Invalid date format $s"))
+}
+
+private[ext] trait ClassType[A, B] {
+  def unwrap(b: B)(implicit format: Formats): A
+  def wrap(a: A)(implicit format: Formats): B
+}
+
+case class ClassSerializer[A : Manifest, B : Manifest](t: ClassType[A, B]) extends Serializer[A] {
+  private val Class = implicitly[Manifest[A]].runtimeClass
+
+  def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), A] = {
+    case (TypeInfo(Class, _), json) => json match {
+      case JNull => null.asInstanceOf[A]
+      case xs: JObject if (xs.extractOpt[B].isDefined) => t.unwrap(xs.extract[B])
+      case value => throw new MappingException(s"Can't convert $value to $Class")
+    }
+  }
+
+  def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
+    case a: A if a.asInstanceOf[AnyRef].getClass == Class => Extraction.decompose(t.wrap(a))
+  }
+}

--- a/tests/src/test/scala/org/json4s/ext/JavaTimeSerializerSpec.scala
+++ b/tests/src/test/scala/org/json4s/ext/JavaTimeSerializerSpec.scala
@@ -1,0 +1,88 @@
+/*
+* Copyright 2007-2011 WorldWide Conferencing, LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.json4s.ext
+
+import java.time._
+
+import org.json4s._
+import org.specs2.mutable.Specification
+
+
+object NativeJavaTimeSerializerSpec extends JavaTimeSerializerSpec("Native") {
+  val s: Serialization = native.Serialization
+}
+
+object JacksonJavaTimeSerializerSpec extends JavaTimeSerializerSpec("Jackson") {
+  val s: Serialization = jackson.Serialization
+}
+
+/**
+* System under specification for JavaTimeSerializer.
+*/
+abstract class JavaTimeSerializerSpec(mod: String) extends Specification {
+
+  def s: Serialization
+  implicit lazy val formats = s.formats(NoTypeHints) ++ JavaTimeSerializers.all
+
+  (mod + " JavaTimeSerializer Specification") should {
+    "Serialize java time types" in {
+      val x = JavaTypes(Duration.ofDays(1),
+                        Instant.ofEpochMilli(1433890789),
+                        Year.of(1987),
+                        LocalDateTime.of(2015, 6, 23, 14, 34, 29),
+                        LocalDate.of(2015, 10, 17),
+                        LocalTime.of(15, 13, 34, 123),
+                        Period.of(2014, 11, 22),
+                        YearMonth.of(1934, 12),
+                        MonthDay.of(11, 24))
+      val ser = s.write(x)
+      s.read[JavaTypes](ser) must_== x
+    }
+
+    "LocalDateTime use configured date format" in {
+      implicit val formats = new DefaultFormats {
+        override def dateFormatter = {
+          new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss'Z'")
+        }
+      } ++ JavaTimeSerializers.all
+
+      val x = JavaDates(LocalDateTime.of(2015, 6, 24, 15, 34, 59))
+      val ser = s.write(x)
+      ser must_== """{"ldt":"2015-06-24 15:34:59Z"}"""
+    }
+
+    "null is serialized as JSON null" in {
+      val x = JavaTypes(null, null, null, null, null, null, null, null, null)
+      val ser = s.write(x)
+      s.read[JavaTypes](ser) must_== x
+    }
+  }
+}
+
+case class JavaTypes(duration: Duration,
+                    instant: Instant,
+                    year: Year,
+                    localDateTime: LocalDateTime,
+                    localDate: LocalDate,
+                    localTime: LocalTime,
+                    period: Period,
+                    yearMonth: YearMonth,
+                    monthDay: MonthDay)
+
+case class JavaDates(ldt: LocalDateTime)
+
+


### PR DESCRIPTION
#### Description

I have recently noticed that you do not support java8 time.

I have added a new CustomSerialiser for the main java8 time classes (package `java.time`):
- `LocalDateTime`
- `Duration`
- `Instant`
- `Year`
- `LocalDate`
- `LocalTime`
- `Period`
- `YearMonth`
- `MonthDay`

#### Implementation Details
The `JavaTimeSerializers` class has been implemented by following the same pattern used for the `JodaTimeSerializers`. Common classes between the Joda and Java Serializers have been extracted in a separate file.

#### !!!
The code requires to be use with Java8, so the project should compiled with JDK8, not JDK7