### PR TITLE
use abstract class instead of trait for binary compatibility

### DIFF
--- a/ast/src/main/scala/org/json4s/JsonAST.scala
+++ b/ast/src/main/scala/org/json4s/JsonAST.scala
@@ -84,7 +84,7 @@ object JsonAST {
   /**
    * Data type for JSON AST.
    */
-  sealed abstract class JValue extends Diff.Diffable {
+  sealed abstract class JValue extends Diff.Diffable with Product with Serializable {
     type Values
 
 

--- a/core/src/main/scala/org/json4s/JsonMethods.scala
+++ b/core/src/main/scala/org/json4s/JsonMethods.scala
@@ -2,7 +2,7 @@ package org.json4s
 
 import java.io.{Reader => JReader, File, InputStream}
 
-sealed trait JsonInput
+sealed abstract class JsonInput extends Product with Serializable
 case class StringInput(string: String) extends JsonInput
 case class ReaderInput(reader: JReader) extends JsonInput
 case class StreamInput(stream: InputStream) extends JsonInput

--- a/core/src/main/scala/org/json4s/ParserUtil.scala
+++ b/core/src/main/scala/org/json4s/ParserUtil.scala
@@ -8,7 +8,7 @@ object ParserUtil {
   private val EOF = (-1).asInstanceOf[Char]
   private val AsciiEncoder = Charset.forName("US-ASCII").newEncoder();
 
-  private[this] trait StringAppender[T] {
+  private[this] sealed abstract class StringAppender[T] {
     def append(s: String): T
     def subj: T
   }
@@ -198,7 +198,7 @@ object ParserUtil {
     }
   }
 
-  sealed trait Segment {
+  sealed abstract class Segment extends Product with Serializable {
     val seg: Array[Char]
   }
   case class RecycledSegment(seg: Array[Char]) extends Segment

--- a/core/src/main/scala/org/json4s/Xml.scala
+++ b/core/src/main/scala/org/json4s/Xml.scala
@@ -96,7 +96,7 @@ object Xml {
     def nameOf(n: Node) = (if (n.prefix ne null) n.prefix + ":" else "") + n.label
     def buildAttrs(n: Node) = n.attributes.map((a: MetaData) => (a.key, XValue(a.value.text))).toList
 
-    sealed trait XElem
+    sealed abstract class XElem extends Product with Serializable
     case class XValue(value: String) extends XElem
     case class XLeaf(value: (String, XElem), attrs: List[(String, XValue)]) extends XElem
     case class XNode(fields: List[(String, XElem)]) extends XElem

--- a/core/src/main/scala/org/json4s/json_writers.scala
+++ b/core/src/main/scala/org/json4s/json_writers.scala
@@ -223,7 +223,7 @@ private final class JDecimalJArrayJsonWriter(parent: JsonWriter[JValue]) extends
 
   def result: JValue = JArray(nodes.toList)
 }
-private sealed trait JValueJsonWriter extends JsonWriter[JValue] {
+private sealed abstract class JValueJsonWriter extends JsonWriter[JValue] {
   
   def addNode(node: JValue): JsonWriter[JValue]
   
@@ -257,7 +257,7 @@ private sealed trait JValueJsonWriter extends JsonWriter[JValue] {
   def addJValue(jv: JValue): JsonWriter[JValue] = addNode(jv)
   
 }
-private sealed trait JDoubleAstJsonWriter extends JValueJsonWriter {
+private sealed abstract class JDoubleAstJsonWriter extends JValueJsonWriter {
   def startArray(): JsonWriter[JValue] = {
     new JDoubleJArrayJsonWriter(this)
   }
@@ -274,7 +274,7 @@ private sealed trait JDoubleAstJsonWriter extends JValueJsonWriter {
   def bigDecimal(value: BigDecimal): JsonWriter[JValue] = addNode(JDouble(value.doubleValue()))
 }
 
-private sealed trait JDecimalAstJsonWriter extends JValueJsonWriter {
+private sealed abstract class JDecimalAstJsonWriter extends JValueJsonWriter {
   def startArray(): JsonWriter[JValue] = {
     new JDecimalJArrayJsonWriter(this)
   }
@@ -468,7 +468,7 @@ private final class RootStreamingJsonWriter[T <: JWriter](protected[this] val no
 
   def result: T = nodes
 }
-private sealed trait StreamingJsonWriter[T <: JWriter] extends JsonWriter[T] {
+private sealed abstract class StreamingJsonWriter[T <: JWriter] extends JsonWriter[T] {
 
   protected[this] def level: Int
   protected[this] def spaces: Int

--- a/core/src/main/scala/org/json4s/reflect/descriptors.scala
+++ b/core/src/main/scala/org/json4s/reflect/descriptors.scala
@@ -4,7 +4,7 @@ package reflect
 import java.lang.reflect.{Constructor => JConstructor, Type, Field, TypeVariable}
 import scala._
 
-sealed trait Descriptor
+sealed abstract class Descriptor extends Product with Serializable
 object ScalaType {
 
   private val types = new Memo[Manifest[_], ScalaType]
@@ -196,7 +196,7 @@ case class ConstructorParamDescriptor(name: String, mangledName: String, argInde
 case class ConstructorDescriptor(params: Seq[ConstructorParamDescriptor], constructor: java.lang.reflect.Constructor[_], isPrimary: Boolean) extends Descriptor
 case class SingletonDescriptor(simpleName: String, fullName: String, erasure: ScalaType, instance: AnyRef, properties: Seq[PropertyDescriptor]) extends Descriptor
 
-sealed trait ObjectDescriptor extends Descriptor
+sealed abstract class ObjectDescriptor extends Descriptor
 case class ClassDescriptor(simpleName: String, fullName: String, erasure: ScalaType, companion: Option[SingletonDescriptor], constructors: Seq[ConstructorDescriptor], properties: Seq[PropertyDescriptor]) extends ObjectDescriptor {
 
   def bestMatching(argNames: List[String]): Option[ConstructorDescriptor] = {

--- a/scalaz/src/main/scala/org/json4s/scalaz/JsonScalaz.scala
+++ b/scalaz/src/main/scala/org/json4s/scalaz/JsonScalaz.scala
@@ -25,7 +25,7 @@ import syntax.validation._
 trait Types {
   type Result[+A] = ValidationNel[Error, A]
 
-  sealed trait Error
+  sealed abstract class Error extends Product with Serializable
   case class UnexpectedJSONError(was: JValue, expected: Class[_ <: JValue]) extends Error
   case class NoSuchFieldError(name: String, json: JValue) extends Error
   case class UncategorizedError(key: String, desc: String, args: List[Any]) extends Error


### PR DESCRIPTION
and add `extends Product with Serializable` for better type inference

for example

```scala
Welcome to Scala version 2.11.7 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_45).
Type in expressions to have them evaluated.
Type :help for more information.

scala> :paste
// Entering paste mode (ctrl-D to finish)

sealed abstract class A
final case class B(value: Int) extends A
final case class C(value: String) extends A

// Exiting paste mode, now interpreting.

defined class A
defined class B
defined class C

scala> List(B(1), C("a"))
res0: List[Product with Serializable with A] = List(B(1), C(a))

scala> :paste
// Entering paste mode (ctrl-D to finish)

sealed abstract class X extends Product with Serializable
final case class Y(value: Int) extends X
final case class Z(value: String) extends X

// Exiting paste mode, now interpreting.

defined class X
defined class Y
defined class Z

scala> List(Y(1), Z("a"))
res1: List[X] = List(Y(1), Z(a))
```