### PR TITLE
Add a builder for Formats.wTypeHintFieldName.

### DIFF
--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -108,6 +108,8 @@ trait Formats { self: Formats =>
 
   def withEmptyValueStrategy(strategy: EmptyValueStrategy): Formats = copy(wEmptyValueStrategy = strategy)
 
+  def withTypeHintFieldName(name: String): Formats = copy(wTypeHintFieldName = name)
+
   /**
    * Adds the specified type hints to this formats.
    */


### PR DESCRIPTION
This is useful if you already have a `Formats` object (e.g., in a `CustomSerializer`) and want to add `TypeHints` with a custom type hint field name.  e.g.:
```Scala
trait Base
case class Foo(redHerring: Int) extends Base
class FieldSerializer extends CustomSerializer[Base](format => (
  {
    implicit val formats =
      format.withTypeHintFieldName("type") + ShortTypeHints(List(classOf[Foo]))
  },
  {...}
)
```

It looks like 3.3 is almost out the door.  Let me know if this PR should be pointed at another branch for a future release.