### PR TITLE
Fix #246 Double.NaN serializes but does not deserialize

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -93,6 +93,13 @@ object Extraction {
     }
   }
 
+  private[this] lazy val typesHaveNaN: Set[Class[_]] = Set(
+    classOf[Double],
+    classOf[Float],
+    classOf[java.lang.Double],
+    classOf[java.lang.Float]
+  )
+
   /** Decompose a case class into JSON.
    *
    * This is broken out to avoid calling builder.result when we return from recursion
@@ -149,6 +156,8 @@ object Extraction {
         current.addJValue(JNull)
       } else if (classOf[JValue].isAssignableFrom(k)) {
         current.addJValue(any.asInstanceOf[JValue])
+      } else if (typesHaveNaN.contains(any.getClass) && any.toString == "NaN") {
+        current.addJValue(JNull)
       } else if (Reflector.isPrimitive(any.getClass)) {
         writePrimitive(any, current)(formats)
       } else if (classOf[scala.collection.Map[_, _]].isAssignableFrom(k)) {

--- a/core/src/main/scala/org/json4s/json_writers.scala
+++ b/core/src/main/scala/org/json4s/json_writers.scala
@@ -559,7 +559,16 @@ private object StreamingJsonWriter {
   private val posInfinityVal = "1e+500"
   private val negInfiniteVal = "-1e+500"
 
-  private def handleInfinity[T <% Any](value: T{ def isPosInfinity: Boolean; def isNegInfinity: Boolean}): String = {
+  private def handleInfinity(value: Float): String = {
+    if(value.isPosInfinity) {
+      posInfinityVal
+    } else if (value.isNegInfinity){
+      negInfiniteVal
+    } else {
+      value.toString
+    }
+  }
+  private def handleInfinity(value: Double): String = {
     if(value.isPosInfinity) {
       posInfinityVal
     } else if (value.isNegInfinity){

--- a/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
+++ b/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
@@ -168,6 +168,22 @@ object SerializationExamples extends Specification {
     read[PlayerWithGenericList](ser) must_== pw
   }
 
+  // #246 Double.NaN serializes but does not deserialize
+  "NaN Float serializes to null example" in {
+    val expected = SingleValue(Float.NaN)
+    val serialized = native.Serialization.write(expected)
+    serialized must_== """{"value":null}"""
+  }
+  "NaN Double serializes to null example" in {
+    val expected = SingleValue(Double.NaN)
+    val serialized = native.Serialization.write(expected)
+    serialized must_== """{"value":null}"""
+  }
+  "NaN String value won't be null" in {
+    val expected = SingleValue("NaN")
+    val serialized = native.Serialization.write(expected)
+    serialized must_== """{"value":"NaN"}"""
+  }
 
   case class Ints(x: List[List[Int]])
 


### PR DESCRIPTION
This pull request fixes #246 issue. This PR will change json4s serializer's behavior to write Double.NaN and Float.NaN as "null" instead of "NaN".