### PR TITLE
Use sbt-javaversioncheck to detect packaging on JDK 8

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -5,6 +5,7 @@ import sbtbuildinfo.Plugin._
 import com.typesafe.sbt.SbtStartScript
 import MimaSettings.mimaSettings
 import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifact
+import com.typesafe.sbt.JavaVersionCheckPlugin.autoImport._
 
 object build extends Build {
   import Dependencies._
@@ -56,6 +57,7 @@ object build extends Build {
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-optimize", "-feature", "-Yinline-warnings", "-language:existentials", "-language:implicitConversions", "-language:higherKinds", "-language:postfixOps"),
     version := "3.3.0-SNAPSHOT",
     javacOptions ++= Seq("-target", "1.6", "-source", "1.6"),
+    javaVersionPrefix in javaVersionCheck := Some("1.7"),
     manifestSetting,
     resolvers ++= Seq(Opts.resolver.sonatypeSnapshots, Opts.resolver.sonatypeReleases),
     crossVersion := CrossVersion.binary

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.typesafe"     % "sbt-mima-plugin"      % "0.1.7")
+addSbtPlugin("com.typesafe.sbt" % "sbt-javaversioncheck" % "0.1.0")
 addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo"        % "0.3.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-start-script"     % "0.10.0")
 addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"         % "0.5.0")

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sbt javaVersionCheck +publishSigned sonatypeRelease


### PR DESCRIPTION
To avoid repeating #299, introducing sbt-javaversioncheck and we'll always use it when publishing libs from now on.