### PR TITLE
Bump jackson version to 2.6, scalaz 7.1.4

### DIFF
--- a/jackson/src/main/scala/org/json4s/jackson/Json.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/Json.scala
@@ -19,10 +19,10 @@ class Json(fmts: Formats, mapper: ObjectMapper = JsonMethods.mapper) extends Jso
   }
 
   def writePretty[A <: AnyRef](a: A): String =
-    mapper.writerWithDefaultPrettyPrinter[ObjectWriter].writeValueAsString(decompose(a))
+    mapper.writerWithDefaultPrettyPrinter.writeValueAsString(decompose(a))
 
   def writePretty[A <: AnyRef, W <: JWriter](a: A, out: W): W = {
-    mapper.writerWithDefaultPrettyPrinter[ObjectWriter].writeValue(out, decompose(a))
+    mapper.writerWithDefaultPrettyPrinter.writeValue(out, decompose(a))
     out
   }
 

--- a/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
@@ -17,7 +17,7 @@ trait JsonMethods extends org.json4s.JsonMethods[JValue] {
   def mapper = _defaultMapper
 
   def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false, useBigIntForLong: Boolean = true): JValue = {
-    var reader = mapper.reader[ObjectReader](classOf[JValue])
+    var reader = mapper.reader(classOf[JValue])
     if (useBigDecimalForDouble) reader = reader `with` USE_BIG_DECIMAL_FOR_FLOATS
     if (useBigIntForLong) reader = reader `with` USE_BIG_INTEGER_FOR_INTS
 
@@ -39,7 +39,7 @@ trait JsonMethods extends org.json4s.JsonMethods[JValue] {
   def compact(d: JValue): String = mapper.writeValueAsString(d)
 
   def pretty(d: JValue): String = {
-    val writer = mapper.writerWithDefaultPrettyPrinter[ObjectWriter]()
+    val writer = mapper.writerWithDefaultPrettyPrinter()
     writer.writeValueAsString(d)
   }
 

--- a/jackson/src/main/scala/org/json4s/jackson/Serialization.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/Serialization.scala
@@ -37,12 +37,12 @@ object Serialization extends Serialization {
   /** Serialize to String (pretty format).
    */
   def writePretty[A <: AnyRef](a: A)(implicit formats: Formats): String =
-    JsonMethods.mapper.writerWithDefaultPrettyPrinter[ObjectWriter].writeValueAsString(Extraction.decompose(a)(formats))
+    JsonMethods.mapper.writerWithDefaultPrettyPrinter.writeValueAsString(Extraction.decompose(a)(formats))
 
   /** Serialize to Writer (pretty format).
    */
   def writePretty[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
-    JsonMethods.mapper.writerWithDefaultPrettyPrinter[ObjectWriter].writeValue(out, Extraction.decompose(a)(formats))
+    JsonMethods.mapper.writerWithDefaultPrettyPrinter.writeValue(out, Extraction.decompose(a)(formats))
     out
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,11 +8,10 @@ object Dependencies {
     "org.joda"  % "joda-convert" % "1.7"
   )
   lazy val jackson      = Seq(
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.3"
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.2"
   )
-  lazy val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3"
-  lazy val liftCommon   = "net.liftweb"                  %% "lift-common"          % "2.5.1"
-  lazy val scalaz_core  = "org.scalaz"                   %% "scalaz-core"          % "7.1.3"
+  lazy val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.1"
+  lazy val scalaz_core  = "org.scalaz"                   %% "scalaz-core"          % "7.1.4"
   lazy val paranamer    = "com.thoughtworks.paranamer"   %  "paranamer"            % "2.8"
   lazy val commonsCodec = "commons-codec"                %  "commons-codec"        % "1.9"
   lazy val specs        = "org.specs2"                   %% "specs2-scalacheck"    % "2.4.17"    % "test"

--- a/project/build.scala
+++ b/project/build.scala
@@ -116,13 +116,6 @@ object build extends Build {
     settings = json4sSettings ++ Seq(libraryDependencies ++= jodaTime)
   ) dependsOn(native % "provided->compile;test->test")
 
-  // TODO: remove this?
-//  lazy val nativeLift = Project(
-//    id = "json4s-native-lift",
-//    base = file("native-lift"),
-//    settings = json4sSettings ++ Seq(libraryDependencies ++= Seq(liftCommon, commonsCodec))
-//  )  dependsOn(native % "compile;test->test")
-
   lazy val jacksonSupport = Project(
     id = "json4s-jackson",
     base = file("jackson"),
@@ -154,7 +147,7 @@ object build extends Build {
      base = file("mongo"),
      settings = json4sSettings ++ Seq(
        libraryDependencies ++= Seq(
-         "org.mongodb" % "mongo-java-driver" % "3.0.3"
+         "org.mongodb" % "mongo-java-driver" % "3.0.4"
       )
   )) dependsOn(core % "compile;test->test")
 


### PR DESCRIPTION
This pull request bumps the following libraries.

- jackson 2.5.x -> 2.6.x
- scalaz 7.1.3 -> 7.1.4
- mongo-java-driver 3.0.3 -> 3.0.4