### PR TITLE
Fix jarray traversal

### DIFF
--- a/core/src/main/scala/org/json4s/MonadicJValue.scala
+++ b/core/src/main/scala/org/json4s/MonadicJValue.scala
@@ -12,12 +12,15 @@ class MonadicJValue(jv: JValue) {
    * json \ "name"
    * </pre>
    */
-  def \(nameToFind: String): JValue =
-    findDirectByName(List(jv), nameToFind) match {
-      case Nil ⇒ JNothing
-      case x :: Nil ⇒ x
-      case x ⇒ JArray(x)
-    }
+  def \(nameToFind: String): JValue = jv match {
+    case JArray(xs) => JArray(findDirectByName(xs, nameToFind))
+    case _ =>
+      findDirectByName(List(jv), nameToFind) match {
+        case Nil ⇒ JNothing
+        case x :: Nil ⇒ x
+        case x ⇒ JArray(x)
+      }
+  }
 
   private[this] def findDirectByName(xs: List[JValue], name: String): List[JValue] = xs.flatMap {
     case JObject(l) ⇒ l.filter {

--- a/tests/src/test/scala/org/json4s/Examples.scala
+++ b/tests/src/test/scala/org/json4s/Examples.scala
@@ -31,6 +31,7 @@ object Examples {
   "lotto":{
     "lotto-id":5,
     "winning-numbers":[2,45,34,23,7,5,3],
+    "lucky-number":[7],
     "winners":[ {
       "winner-id":23,
       "numbers":[2,45,34,23,3, 5]
@@ -84,6 +85,22 @@ object Examples {
     {
       "name": "Mazy",
       "age": 3
+    }
+  ]
+}
+"""
+
+  val objArray2 =
+"""
+{ "name": "joe",
+  "address": {
+    "street": "Bulevard",
+    "city": "Helsinki"
+  },
+  "children": [
+    {
+      "name": "Mary",
+      "age": 2
     }
   ]
 }
@@ -164,6 +181,11 @@ abstract class Examples[T](mod: String) extends Specification with JsonMethods[T
       compact(render((json \ "children")(0) \ "name")) must_== "\"Mary\""
       compact(render((json \ "children")(1) \ "name")) must_== "\"Mazy\""
       (for { JObject(o) <- json; JField("name", JString(y)) <- o } yield y) must_== List("joe", "Mary", "Mazy")
+    }
+
+    "Object array example 2" in {
+      compact(render(parse(lotto) \ "lotto" \ "lucky-number")) must_== """[7]"""
+      compact(render(parse(objArray2) \ "children" \ "name")) must_== """["Mary"]"""
     }
 
     "Unbox values using XPath-like type expression" in {

--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -342,7 +342,7 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
 """
 {
   "ints": [[[1, 2], [3]], [[4], [5, 6]]],
-  "names": [[{"name": "joe"}, {"name": "mary"}], [[{"name": "mazy"}]]]
+  "names": [[{"name": "joe"}, {"name": "mary"}], [{"name": "mazy"}]]
 }
 """
 


### PR DESCRIPTION
When doing a traversal over a JSON array containing a single element, a primitive was returned. If the array contains more than a single elements, a JArray was returned instead. This is not consistent.

This patch is a breaking change, so it is merely a proposal. What do you think?