### PR TITLE
Support deserialization into mutable collections #138

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -423,10 +423,10 @@ object Extraction {
       else if (tpe.erasure == classOf[List[_]]) mkCollection(a => List(a: _*))
       else if (tpe.erasure == classOf[Set[_]]) mkCollection(a => Set(a: _*))
       else if (tpe.erasure == classOf[scala.collection.mutable.Set[_]]) mkCollection(a => scala.collection.mutable.Set(a: _*))
+      else if (tpe.erasure == classOf[scala.collection.mutable.Seq[_]]) mkCollection(a => scala.collection.mutable.Seq(a: _*))
       else if (tpe.erasure == classOf[java.util.ArrayList[_]]) mkCollection(a => new java.util.ArrayList[Any](a.toList.asJavaCollection))
       else if (tpe.erasure.isArray) mkCollection(mkTypedArray)
       else if (classOf[Seq[_]].isAssignableFrom(tpe.erasure)) mkCollection(a => Seq(a: _*))
-      else if (classOf[scala.collection.mutable.Seq[_]].isAssignableFrom(tpe.erasure)) mkCollection(a => scala.collection.mutable.Seq(a: _*))
       else fail("Expected collection but got " + tpe)
     }
   }

--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -422,9 +422,11 @@ object Extraction {
       if (custom.isDefinedAt(tpe.typeInfo, json)) custom(tpe.typeInfo, json)
       else if (tpe.erasure == classOf[List[_]]) mkCollection(a => List(a: _*))
       else if (tpe.erasure == classOf[Set[_]]) mkCollection(a => Set(a: _*))
+      else if (tpe.erasure == classOf[scala.collection.mutable.Set[_]]) mkCollection(a => scala.collection.mutable.Set(a: _*))
       else if (tpe.erasure == classOf[java.util.ArrayList[_]]) mkCollection(a => new java.util.ArrayList[Any](a.toList.asJavaCollection))
       else if (tpe.erasure.isArray) mkCollection(mkTypedArray)
       else if (classOf[Seq[_]].isAssignableFrom(tpe.erasure)) mkCollection(a => Seq(a: _*))
+      else if (classOf[scala.collection.mutable.Seq[_]].isAssignableFrom(tpe.erasure)) mkCollection(a => scala.collection.mutable.Seq(a: _*))
       else fail("Expected collection but got " + tpe)
     }
   }

--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -186,6 +186,28 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
       json.extract[Map[String, String]] must_== Map("street" -> "Bulevard", "city" -> "Helsinki")
     }
 
+    "Set extraction example" in {
+      val json = parse(testJson) \ "children"
+      json.extract[Set[Name]] must_== Set(Name("Mary"), Name("Mazy"))
+    }
+
+    "Seq extraction example" in {
+      val json = parse(testJson) \ "children"
+      json.extract[Seq[Name]] must_== Seq(Name("Mary"), Name("Mazy"))
+    }
+
+    "Mutable set extraction example" in {
+      val json = parse(testJson) \ "children"
+      json.extract[scala.collection.mutable.Set[Name]] must_==
+        scala.collection.mutable.Set(Name("Mary"), Name("Mazy"))
+    }
+
+    "Mutable seq extraction example" in {
+      val json = parse(testJson) \ "children"
+      json.extract[scala.collection.mutable.Seq[Name]] must_==
+        scala.collection.mutable.Seq(Name("Mary"), Name("Mazy"))
+    }
+
     "Extraction and decomposition are symmetric" in {
       val person = parse(testJson).extract[Person]
       Extraction.decompose(person).extract[Person] must_== person


### PR DESCRIPTION
Added support for mutable sets (and seqs too, while I was at it), in the extraction class. For a description of the problem, please refer to [issue#138](https://github.com/json4s/json4s/issues/138).