### PR TITLE
Added a strictArrayCreation formats flag to disable automatic creatio…

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -401,7 +401,7 @@ object Extraction {
     private[this] def mkCollection(constructor: Array[_] => Any) = {
       val array: Array[_] = json match {
         case JArray(arr)      => arr.map(extract(_, typeArg)).toArray
-        case JNothing | JNull => Array[AnyRef]()
+        case JNothing | JNull if !formats.strictArrayCreation => Array[AnyRef]()
         case x                => fail("Expected collection but got " + x + " for root " + json + " and mapping " + tpe)
       }
 

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -49,6 +49,7 @@ trait Formats extends Serializable { self: Formats =>
   def companions: List[(Class[_], AnyRef)] = Nil
   def allowNull: Boolean = true
   def strictOptionParsing: Boolean = false
+  def strictArrayCreation: Boolean = false
 
   /**
    * The name of the field in JSON where type hints are added (jsonClass by default)
@@ -74,7 +75,8 @@ trait Formats extends Serializable { self: Formats =>
                     wWantsBigDecimal: Boolean = self.wantsBigDecimal,
                     withPrimitives: Set[Type] = self.primitives,
                     wCompanions: List[(Class[_], AnyRef)] = self.companions,
-                    wStrict: Boolean = self.strictOptionParsing,
+                    wStrictOptionParsing: Boolean = self.strictOptionParsing,
+                    wStrictArrayCreation: Boolean = self.strictArrayCreation,
                     wEmptyValueStrategy: EmptyValueStrategy = self.emptyValueStrategy): Formats =
     new Formats {
       def dateFormat: DateFormat = wDateFormat
@@ -88,7 +90,8 @@ trait Formats extends Serializable { self: Formats =>
       override def wantsBigDecimal: Boolean = wWantsBigDecimal
       override def primitives: Set[Type] = withPrimitives
       override def companions: List[(Class[_], AnyRef)] = wCompanions
-      override def strictOptionParsing: Boolean = wStrict
+      override def strictOptionParsing: Boolean = wStrictOptionParsing
+      override def strictArrayCreation: Boolean = wStrictArrayCreation
       override def emptyValueStrategy: EmptyValueStrategy = wEmptyValueStrategy
     }
 
@@ -338,6 +341,7 @@ trait Formats extends Serializable { self: Formats =>
     override val primitives: Set[Type] = Set(classOf[JValue], classOf[JObject], classOf[JArray])
     override val companions: List[(Class[_], AnyRef)] = Nil
     override val strictOptionParsing: Boolean = false
+    override val strictArrayCreation: Boolean = false
     override val emptyValueStrategy: EmptyValueStrategy = EmptyValueStrategy.default
     override val allowNull: Boolean = true
 

--- a/tests/src/test/scala/org/json4s/StrictArrayCreationSpec.scala
+++ b/tests/src/test/scala/org/json4s/StrictArrayCreationSpec.scala
@@ -1,0 +1,34 @@
+package org.json4s
+
+import org.specs2.mutable.Specification
+
+import scala.text.Document
+
+object NativeStrictArrayCreationSpec extends StrictArrayCreationSpec[Document]("Native") with native.JsonMethods
+object JacksonStrictArrayCreationSpec extends StrictArrayCreationSpec[JValue]("Jackson") with jackson.JsonMethods
+
+abstract class StrictArrayCreationSpec[T](mod: String) extends Specification with JsonMethods[T] {
+
+  implicit lazy val formats = new DefaultFormats { override val strictArrayCreation = true }
+
+  val doesNotContainArray  = """{}"""
+  val containsEmptyArray  = """{"array":[]}"""
+  val containsNonEmptyArray  = """{"array":[1,2]}"""
+
+  (mod + " case class with a single array element in strict mode") should {
+    "throw an error on parsing an object without the required key" in {
+      (parse(doesNotContainArray).extract[SingleArrayModel]) must throwA[MappingException]
+    }
+    "successfully parse an empty array" in {
+      val model = parse(containsEmptyArray).extract[SingleArrayModel]
+      model.array must_== Array()
+    }
+    "successfully parse a non empty array" in {
+      val model = parse(containsNonEmptyArray).extract[SingleArrayModel]
+      model.array must_== Array(1, 2)
+    }
+  }
+
+}
+
+case class SingleArrayModel(array: Array[Int])


### PR DESCRIPTION
Creates a new formats flag that disables the automatic creation of empty arrays if a key is not provided.

case class Example(arr: Array[Int])

val ex = parse("{}").extract[Example]

Without the flag, ex will = Example(arr = Array())
With the flag, extract will fail
