### PR TITLE
Added a strictStringConversion option to formats to allow disabling o…

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -614,7 +614,7 @@ object Extraction {
       case JInt(x) if (targetType == classOf[JavaShort]) => new JavaShort(x.shortValue)
       case JInt(x) if (targetType == classOf[Byte]) => x.byteValue
       case JInt(x) if (targetType == classOf[JavaByte]) => new JavaByte(x.byteValue)
-      case JInt(x) if (targetType == classOf[String]) => x.toString
+      case JInt(x) if (!formats.strictStringConversion && targetType == classOf[String]) => x.toString
       case JInt(x) if (targetType == classOf[Number]) => x.longValue
       case JInt(x) if (targetType == classOf[BigDecimal]) => BigDecimal(x)
       case JInt(x) if (targetType == classOf[JavaBigDecimal]) => BigDecimal(x).bigDecimal
@@ -631,7 +631,7 @@ object Extraction {
       case JLong(x) if (targetType == classOf[JavaShort]) => new JavaShort(x.shortValue)
       case JLong(x) if (targetType == classOf[Byte]) => x.byteValue
       case JLong(x) if (targetType == classOf[JavaByte]) => new JavaByte(x.byteValue)
-      case JLong(x) if (targetType == classOf[String]) => x.toString
+      case JLong(x) if (!formats.strictStringConversion && targetType == classOf[String]) => x.toString
       case JLong(x) if (targetType == classOf[Number]) => x.longValue
       case JLong(x) if (targetType == classOf[BigDecimal]) => BigDecimal(x)
       case JLong(x) if (targetType == classOf[JavaBigDecimal]) => BigDecimal(x).bigDecimal
@@ -639,7 +639,7 @@ object Extraction {
       case JDouble(x) if (targetType == classOf[JavaDouble]) => new JavaDouble(x)
       case JDouble(x) if (targetType == classOf[Float]) => x.floatValue
       case JDouble(x) if (targetType == classOf[JavaFloat]) => new JavaFloat(x.floatValue)
-      case JDouble(x) if (targetType == classOf[String]) => x.toString
+      case JDouble(x) if (!formats.strictStringConversion && targetType == classOf[String]) => x.toString
       case JDouble(x) if (targetType == classOf[Int]) => x.intValue
       case JDouble(x) if (targetType == classOf[Long]) => x.longValue
       case JDouble(x) if (targetType == classOf[Number]) => x
@@ -651,7 +651,7 @@ object Extraction {
       case JDecimal(x) if (targetType == classOf[JavaBigDecimal]) => x.bigDecimal
       case JDecimal(x) if (targetType == classOf[Float]) => x.floatValue
       case JDecimal(x) if (targetType == classOf[JavaFloat]) => new JavaFloat(x.floatValue)
-      case JDecimal(x) if (targetType == classOf[String]) => x.toString
+      case JDecimal(x) if (!formats.strictStringConversion && targetType == classOf[String]) => x.toString
       case JDecimal(x) if (targetType == classOf[Int]) => x.intValue
       case JDecimal(x) if (targetType == classOf[Long]) => x.longValue
       case JDecimal(x) if (targetType == classOf[Number]) => x

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -49,6 +49,7 @@ trait Formats extends Serializable { self: Formats =>
   def companions: List[(Class[_], AnyRef)] = Nil
   def allowNull: Boolean = true
   def strictOptionParsing: Boolean = false
+  def strictStringConversion: Boolean = false
 
   /**
    * The name of the field in JSON where type hints are added (jsonClass by default)
@@ -74,7 +75,8 @@ trait Formats extends Serializable { self: Formats =>
                     wWantsBigDecimal: Boolean = self.wantsBigDecimal,
                     withPrimitives: Set[Type] = self.primitives,
                     wCompanions: List[(Class[_], AnyRef)] = self.companions,
-                    wStrict: Boolean = self.strictOptionParsing,
+                    wStrictOptionParsing: Boolean = self.strictOptionParsing,
+                    wStrictStringConversion: Boolean = self.strictStringConversion,
                     wEmptyValueStrategy: EmptyValueStrategy = self.emptyValueStrategy): Formats =
     new Formats {
       def dateFormat: DateFormat = wDateFormat
@@ -88,7 +90,8 @@ trait Formats extends Serializable { self: Formats =>
       override def wantsBigDecimal: Boolean = wWantsBigDecimal
       override def primitives: Set[Type] = withPrimitives
       override def companions: List[(Class[_], AnyRef)] = wCompanions
-      override def strictOptionParsing: Boolean = wStrict
+      override def strictOptionParsing: Boolean = wStrictOptionParsing
+      override def strictStringConversion: Boolean = wStrictStringConversion
       override def emptyValueStrategy: EmptyValueStrategy = wEmptyValueStrategy
     }
 
@@ -338,6 +341,7 @@ trait Formats extends Serializable { self: Formats =>
     override val primitives: Set[Type] = Set(classOf[JValue], classOf[JObject], classOf[JArray])
     override val companions: List[(Class[_], AnyRef)] = Nil
     override val strictOptionParsing: Boolean = false
+    override val strictStringConversion: Boolean = false
     override val emptyValueStrategy: EmptyValueStrategy = EmptyValueStrategy.default
     override val allowNull: Boolean = true
 

--- a/tests/src/test/scala/org/json4s/StrictStringConversionSpec.scala
+++ b/tests/src/test/scala/org/json4s/StrictStringConversionSpec.scala
@@ -1,0 +1,38 @@
+package org.json4s
+
+import org.specs2.mutable.Specification
+
+import scala.text.Document
+
+object NativeStrictStringConversionSpec extends StrictStringConversionSpec[Document]("Native") with native.JsonMethods
+object JacksonStrictStringConversionSpec extends StrictStringConversionSpec[JValue]("Jackson") with jackson.JsonMethods
+
+abstract class StrictStringConversionSpec[T](mod: String) extends Specification with JsonMethods[T] {
+
+  implicit lazy val formats = new DefaultFormats { override val strictStringConversion = true }
+
+  (mod + " case class with string element in strict mode") should {
+    "throw an error on parsing a JInt as that string" in {
+      (JObject(JField("str", JInt(1))).extract[BasicStrModel]) must throwA[MappingException]
+    }
+
+    "throw an error on parsing a JLong as that string" in {
+      (JObject(JField("str", JLong(1))).extract[BasicStrModel]) must throwA[MappingException]
+    }
+
+    "throw an error on parsing a JDouble as that string" in {
+      (JObject(JField("str", JDouble(1))).extract[BasicStrModel]) must throwA[MappingException]
+    }
+
+    "throw an error on parsing a JDecimal as that string" in {
+      (JObject(JField("str", JDecimal(1))).extract[BasicStrModel]) must throwA[MappingException]
+    }
+
+    "throw an error on parsing a JInt as that string" in {
+      val model = JObject(JField("str", JString("test"))).extract[BasicStrModel]
+      model.str must_== "test"
+    }
+  }
+}
+
+case class BasicStrModel(str: String)


### PR DESCRIPTION
Creates a new formats flag that disables the automatic conversion of numeric types to strings.

case class Example(str: String)

val ex = parse("""{"str":1}""").extract[Example]

Without the flag, ex will = Example(str = "1")
With the flag, extract will fail
