### PR TITLE
Escaping unicode characters should be option in formats

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -272,7 +272,7 @@ object Extraction {
 
   /** Flattens the JSON to a key/value map.
    */
-  def flatten(json: JValue): Map[String, String] = {
+  def flatten(json: JValue)(implicit formats: Formats = DefaultFormats): Map[String, String] = {
     def escapePath(str: String) = str
 
     def flatten0(path: String, json: JValue): Map[String, String] = {

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -49,6 +49,7 @@ trait Formats extends Serializable { self: Formats =>
   def companions: List[(Class[_], AnyRef)] = Nil
   def allowNull: Boolean = true
   def strictOptionParsing: Boolean = false
+  def alwaysEscapeUnicode: Boolean = false
 
   /**
    * The name of the field in JSON where type hints are added (jsonClass by default)
@@ -75,6 +76,7 @@ trait Formats extends Serializable { self: Formats =>
                     withPrimitives: Set[Type] = self.primitives,
                     wCompanions: List[(Class[_], AnyRef)] = self.companions,
                     wStrict: Boolean = self.strictOptionParsing,
+                    wAlwaysEscapeUnicode: Boolean = self.alwaysEscapeUnicode,
                     wEmptyValueStrategy: EmptyValueStrategy = self.emptyValueStrategy): Formats =
     new Formats {
       def dateFormat: DateFormat = wDateFormat
@@ -89,6 +91,7 @@ trait Formats extends Serializable { self: Formats =>
       override def primitives: Set[Type] = withPrimitives
       override def companions: List[(Class[_], AnyRef)] = wCompanions
       override def strictOptionParsing: Boolean = wStrict
+      override def alwaysEscapeUnicode: Boolean = wAlwaysEscapeUnicode
       override def emptyValueStrategy: EmptyValueStrategy = wEmptyValueStrategy
     }
 
@@ -109,6 +112,8 @@ trait Formats extends Serializable { self: Formats =>
   def withEmptyValueStrategy(strategy: EmptyValueStrategy): Formats = copy(wEmptyValueStrategy = strategy)
 
   def withTypeHintFieldName(name: String): Formats = copy(wTypeHintFieldName = name)
+
+  def withEscapeUnicode: Formats = copy(wAlwaysEscapeUnicode = true)
 
   /**
    * Adds the specified type hints to this formats.

--- a/native/src/main/scala/org/json4s/native/Serialization.scala
+++ b/native/src/main/scala/org/json4s/native/Serialization.scala
@@ -40,7 +40,7 @@ object Serialization extends Serialization  {
   /** Serialize to Writer.
    */
   def write[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
-    Extraction.decomposeWithBuilder(a, JsonWriter.streaming(out))(formats)
+    Extraction.decomposeWithBuilder(a, JsonWriter.streaming(out)(formats))(formats)
   }
 
   /** Serialize to String (pretty format).
@@ -51,7 +51,7 @@ object Serialization extends Serialization  {
   /** Serialize to Writer (pretty format).
    */
   def writePretty[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
-    Extraction.decomposeWithBuilder(a, JsonWriter.streamingPretty(out))(formats)
+    Extraction.decomposeWithBuilder(a, JsonWriter.streamingPretty(out)(formats))(formats)
   }
 
   /** Serialize to String (pretty format).

--- a/tests/src/test/scala/org/json4s/native/SerializationBugs.scala
+++ b/tests/src/test/scala/org/json4s/native/SerializationBugs.scala
@@ -142,8 +142,12 @@ object SerializationBugs extends Specification {
 
   "Escapes control characters" in {
     val ser = native.Serialization.write("\u0000\u001f")
-    // #179 changed the behaviro (https://github.com/json4s/json4s/pull/179)
-    //ser must_== "\"\\u0000\\u001f\""
+    ser must_== "\"\\u0000\\u001f\""
+  }
+
+  "Escapes control and unicode characters" in {
+    val formats = DefaultFormats.withEscapeUnicode
+    val ser = native.Serialization.write("\u0000\u001f")(formats)
     ser must_== "\"\u0000\u001f\""
   }
 


### PR DESCRIPTION
Thanks so much for creating this awesome json library. I hope I can pay you back by contributing this little improvement.

The 3.3 unicode change breaks backward:
https://github.com/json4s/json4s/pull/179

I understand that @jilen got valid use case to escape all unicode characters, but on the other hand as @casualjim noted, not escaping unicode is JSON standard and that's how most JSON library handles that.

My proposal, don't escape unicode characters by default, but provide option in formats to do that if you need it. That way we all could live together happily.

Source:
Section 9: http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
Question on SO: http://stackoverflow.com/questions/12271547/shouldnt-json-stringify-escape-unicode-characters