### PR TITLE
Bump minor version of dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,18 +4,21 @@ import Keys._
 object Dependencies {
 
   lazy val jodaTime     = Seq(
-    "joda-time" % "joda-time"    % "2.8.2",
-    "org.joda"  % "joda-convert" % "1.7"
+    "joda-time" % "joda-time"    % "2.9.2",
+    "org.joda"  % "joda-convert" % "1.8.1"
   )
   lazy val jackson      = Seq(
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.2"
+    // TODO: 2.7
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.5"
   )
-  lazy val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.1"
-  lazy val scalaz_core  = "org.scalaz"                   %% "scalaz-core"          % "7.1.4"
+  lazy val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.3"
+  // TODO: 7.2
+  lazy val scalaz_core  = "org.scalaz"                   %% "scalaz-core"          % "7.1.7"
   lazy val paranamer    = "com.thoughtworks.paranamer"   %  "paranamer"            % "2.8"
   lazy val commonsCodec = "commons-codec"                %  "commons-codec"        % "1.9"
-  lazy val specs        = "org.specs2"                   %% "specs2-scalacheck"    % "2.4.17"    % "test"
-  lazy val mockito      = "org.mockito"                  %  "mockito-all"          % "1.10.19"   % "test"
+  // NOTE: keep 2.4 to be compatible with scalaz 7.1
+  lazy val specs        = "org.specs2"                   %% "specs2-scalacheck"    % "2.4.17"  % "test"
+  lazy val mockito      = "org.mockito"                  %  "mockito-all"          % "1.10.19" % "test"
 
   def scalaXml(scalaVersion: String) = {
     PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion)){

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -4,17 +4,21 @@ import com.typesafe.tools.mima.plugin.MimaKeys._
 
 object MimaSettings {
 
+  // TODO: Enable this after 3.4.0 release
+  // val previousVersions = Set(0).map(patch => s"3.4.$patch")
+  val previousVersions: Set[String] = Set.empty
+
   val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
-    previousArtifact := {
+    previousArtifacts := {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, scalaMajor)) if scalaMajor <= 11 =>
-          // NOTE: when we start 3.4.0 release, enable this mima setting
-          // previousArtifact must always be the previous version (e.g.) verify 3.4.2 for 3.4.3 build
-          // Some(organization.value % s"${name.value}_${scalaBinaryVersion.value}" % "3.4.0")
-          None
-        case _ =>
-          None
+          previousVersions.map { organization.value % s"${name.value}_${scalaBinaryVersion.value}" % _ }
+        case _ => Set.empty
       }
+    },
+    test in Test := {
+      reportBinaryIssues.value
+      (test in Test).value
     }
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.10-RC3

--- a/project/build.scala
+++ b/project/build.scala
@@ -4,7 +4,7 @@ import xml.Group
 import sbtbuildinfo.Plugin._
 import com.typesafe.sbt.SbtStartScript
 import MimaSettings.mimaSettings
-import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifact
+import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifacts
 import com.typesafe.sbt.JavaVersionCheckPlugin.autoImport._
 
 object build extends Build {
@@ -64,7 +64,7 @@ object build extends Build {
   ) ++ mimaSettings
 
   val noPublish = Seq(
-    previousArtifact := None,
+    previousArtifacts := Set(),
     publishArtifact := false,
     publish := {},
     publishLocal := {}
@@ -147,7 +147,7 @@ object build extends Build {
      base = file("mongo"),
      settings = json4sSettings ++ Seq(
        libraryDependencies ++= Seq(
-         "org.mongodb" % "mongo-java-driver" % "3.0.4"
+         "org.mongodb" % "mongo-java-driver" % "3.2.1"
       )
   )) dependsOn(core % "compile;test->test")
 
@@ -172,7 +172,7 @@ object build extends Build {
       libraryDependencies ++= Seq(
         "com.google.code.java-allocation-instrumenter" % "java-allocation-instrumenter" % "3.0",
         "com.google.caliper" % "caliper" % "0.5-rc1",
-        "com.google.code.gson" % "gson" % "2.3.1"
+        "com.google.code.gson" % "gson" % "2.6"
       ),
       libraryDependencies += jacksonScala,
       runner in Compile in run <<= (thisProject, taskTemporaryDirectory, scalaInstance, baseDirectory, javaOptions, outputStrategy, javaHome, connectInput) map {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
-addSbtPlugin("com.typesafe"     % "sbt-mima-plugin"      % "0.1.7")
+addSbtPlugin("com.typesafe"     % "sbt-mima-plugin"      % "0.1.8")
 addSbtPlugin("com.typesafe.sbt" % "sbt-javaversioncheck" % "0.1.0")
 addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo"        % "0.3.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-start-script"     % "0.10.0")
-addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"         % "0.5.0")
+addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"         % "1.0")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"              % "1.0.0")
-addSbtPlugin("com.timushev.sbt" % "sbt-updates"          % "0.1.9")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates"          % "0.1.10")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 


### PR DESCRIPTION
This pull request bumps minor version as below:

 - joda-time 2.8.2 -> 2.9.2
 - jackson 2.6.2 -> 2.6.5
 - scalaz 7.1.4 -> 7.1.7
 - sbt 0.13.9 -> 0.13.10-RC3
 - sbt-mima-plugin 0.1.7 -> 0.1.8
