### PR TITLE
Not match better info 3.4

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -533,8 +533,8 @@ object Extraction {
       } catch {
         case e @ (_:IllegalArgumentException | _:InstantiationException) =>
           val argsTypeComparisonResult = {
-            val constructorParamTypes = jconstructor.getParameterTypes().map(Some(_))
-            val argTypes = args.map(arg => Some(if (arg != null) arg.getClass else null))
+            val constructorParamTypes = jconstructor.getParameterTypes().map(paramType => Some(paramType.asInstanceOf[Class[Any]]))
+            val argTypes = args.map(arg => Some(if (arg != null) arg.getClass.asInstanceOf[Class[Any]] else null))
             constructorParamTypes.zipAll(argTypes, None, None).map {
               case (None, Some(argType)) =>
                 s"REDUNDANT(${argType.getName})"

--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -532,10 +532,26 @@ object Extraction {
         }
       } catch {
         case e @ (_:IllegalArgumentException | _:InstantiationException) =>
+          val argsTypeComparisonResult = {
+            val constructorParamTypes = jconstructor.getParameterTypes().map(Some(_))
+            val argTypes = args.map(arg => Some(if (arg != null) arg.getClass else null))
+            constructorParamTypes.zipAll(argTypes, None, None).map {
+              case (None, Some(argType)) =>
+                s"REDUNDANT(${argType.getName})"
+              case (Some(constructorParamType), None) =>
+                s"MISSING(${constructorParamType.getName})"
+              case (Some(constructorParamType), Some(argType)) if argType == null || constructorParamType.isAssignableFrom(argType) =>
+                "MATCH"
+              case (Some(constructorParamType), Some(argType)) =>
+                s"${argType.getName}(${argType.getClassLoader}) !<: ${constructorParamType.getName}(${constructorParamType.getClassLoader})"
+            }
+          }
           fail("Parsed JSON values do not match with class constructor\nargs=" +
                args.mkString(",") + "\narg types=" + args.map(a => if (a != null)
                  a.asInstanceOf[AnyRef].getClass.getName else "null").mkString(",") +
-               "\nconstructor=" + jconstructor)
+               "\nexecutable=" + jconstructor +
+               "\ncause=" + e.getMessage +
+               "\ntypes comparison result=" + argsTypeComparisonResult.mkString(","))
       }
     }
 

--- a/core/src/main/scala/org/json4s/reflect/Executable.scala
+++ b/core/src/main/scala/org/json4s/reflect/Executable.scala
@@ -59,4 +59,8 @@ class Executable private (val method: Method, val constructor: Constructor[_]) {
     else constructor
   }
 
+  override def toString =
+    if (method != null)
+      s"Executable(Method($method))"
+    else s"Executable(Constructor($constructor))"
 }


### PR DESCRIPTION
Before the change in this most common problem situation was only shown arguments, their types and org.json4s.Executable@hashCode as a constructor.

After change there is shown real constructor signature, cause of problem and positions that not match. Additional there are presented classloaders because I ocurred situation: scala.collection.immutable.Nil$ !<: scala.collection.immutable.Seq which shouldn't happen on the same classloaders.

It really helps investigating problems.

Cheers,
Arek