### PR TITLE
Added Reflector test and fix for case classes with Option types defined inside traits

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/Reflector.scala
+++ b/core/src/main/scala/org/json4s/reflect/Reflector.scala
@@ -146,7 +146,7 @@ object Reflector {
               val decoded = unmangleName(paramName)
               val default = companion flatMap { comp => defaultValue(comp.erasure.erasure, comp.instance, index) }
               //println(s"$paramName $index $tpe $ctorParameterNames ${genParams(index)}")
-              val theType = ctorParamType(paramName, index, tpe, ctorParameterNames.toList, genParams(index))
+              val theType = ctorParamType(paramName, index, tpe, ctorParameterNames.filterNot(_==ScalaSigReader.OuterFieldName).toList, genParams(index))
               ConstructorParamDescriptor(decoded, paramName, index, theType, default)
             }
           }


### PR DESCRIPTION
There are other cases to test within a trait, eg tests for `FromTraitTypeParam`, which would also have issues, but this fix is for the RROption case only.