### PR TITLE
Polished json4s-scalaz a bit

### DIFF
--- a/scalaz/src/main/scala/org/json4s/scalaz/JsonScalaz.scala
+++ b/scalaz/src/main/scala/org/json4s/scalaz/JsonScalaz.scala
@@ -140,9 +140,9 @@ trait Types {
       }
     }
 
-    def orElse[B >: A](fa2: JSONR[B]): JSONR[B] = new JSONR[B] {
+    def orElse[B >: A](fb: JSONR[B]): JSONR[B] = new JSONR[B] {
       override def read(json: JValue): Result[B] = {
-        fa.read(json) orElse fa2.read(json)
+        fa.read(json) orElse fb.read(json)
       }
     }
 
@@ -150,16 +150,16 @@ trait Types {
 
   implicit class JSONExt[A](fa: JSON[A]) {
 
-    def xmap[B](f1: A => B, f2: B => A): JSON[B] = new JSON[B] {
-      override def write(value: B): JValue = (fa:JSONW[A]).contramap(f2).write(value)
+    def xmap[B](f: A => B, g: B => A): JSON[B] = new JSON[B] {
+      override def write(value: B): JValue = (fa:JSONW[A]).contramap(g).write(value)
 
-      override def read(json: JValue): Result[B] = (fa:JSONR[A]).map(f1).read(json)
+      override def read(json: JValue): Result[B] = (fa:JSONR[A]).map(f).read(json)
     }
 
-    def exmap[B](f1: A => Result[B], f2: B => A): JSON[B] = new JSON[B] {
-      override def write(value: B): JValue = (fa:JSONW[A]).contramap(f2).write(value)
+    def exmap[B](f: A => Result[B], g: B => A): JSON[B] = new JSON[B] {
+      override def write(value: B): JValue = (fa:JSONW[A]).contramap(g).write(value)
 
-      override def read(json: JValue): Result[B] = (fa:JSONR[A]).emap(f1).read(json)
+      override def read(json: JValue): Result[B] = (fa:JSONR[A]).emap(f).read(json)
     }
 
   }

--- a/scalaz/src/main/scala/org/json4s/scalaz/JsonScalaz.scala
+++ b/scalaz/src/main/scala/org/json4s/scalaz/JsonScalaz.scala
@@ -19,6 +19,9 @@ package scalaz
 
 import _root_.scalaz._
 import std.option._
+import syntax.applicative._
+import syntax.validation._
+import syntax.contravariant._
 
 
 trait Types {
@@ -56,6 +59,120 @@ trait Types {
 
   def fromJSON[A: JSONR](json: JValue): Result[A] = implicitly[JSONR[A]].read(json)
   def toJSON[A: JSONW](value: A): JValue = implicitly[JSONW[A]].write(value)
+
+  object JSONW {
+
+    def apply[A:JSONW]: JSONW[A] = implicitly[JSONW[A]]
+
+    def instance[A](f: A => JValue): JSONW[A] = new JSONW[A] {
+      def write(a: A) = f(a)
+    }
+
+  }
+
+
+  object JSONR {
+
+    def apply[A:JSONR]: JSONR[A] = implicitly[JSONR[A]]
+
+    def instance[A](f: JValue => Result[A]): JSONR[A] = new JSONR[A] {
+      def read(json: JValue) = f(json)
+    }
+
+    def instanceE[A](f: JValue => Error \/ A): JSONR[A] = new JSONR[A] {
+      def read(json: JValue) = f(json).validationNel
+    }
+
+  }
+
+  object JSON {
+
+    def apply[A:JSON](implicit jsonA: JSON[A]): JSON[A] = jsonA
+
+    def instance[A](f: JValue => Result[A], g: A => JValue): JSON[A] = new JSON[A] {
+      override def read(json: JValue): Result[A] = f(json)
+      override def write(value: A): JValue = g(value)
+    }
+
+    implicit def JSONfromJSONRW[A](implicit readA: JSONR[A], writeA: JSONW[A]): JSON[A] = new JSON[A] {
+      override def read(json: JValue): Result[A] = readA.read(json)
+      override def write(value: A): JValue = writeA.write(value)
+    }
+
+  }
+
+
+  implicit val jsonrMonad = new Monad[JSONR] {
+
+    override def point[A](a: => A): JSONR[A] = new JSONR[A] {
+      override def read(json: JValue): Result[A] = a.successNel
+    }
+
+    override def bind[A, B](fa: JSONR[A])(f: (A) => JSONR[B]): JSONR[B] = new JSONR[B] {
+      override def read(json: JValue): Result[B] = {
+        fa.read(json) match {
+          case Success(a) => f(a).read(json)
+          case Failure(error) => Failure(error)
+        }
+      }
+    }
+
+  }
+
+  implicit val jsonwContravariant = new Contravariant[JSONW] {
+
+    override def contramap[A, B](r: JSONW[A])(f: (B) => A): JSONW[B] = new JSONW[B] {
+      override def write(value: B): JValue = {
+        r.write(f(value))
+      }
+    }
+
+  }
+
+  implicit class JSONRExt[A](fa: JSONR[A]) {
+
+    def emap[B](f: A => Result[B]): JSONR[B] = new JSONR[B] {
+      override def read(json: JValue): Result[B] = {
+        fa.read(json) match {
+          case Success(a) => f(a)
+          case f@Failure(error) => f
+        }
+      }
+    }
+
+    def orElse[B >: A](fa2: JSONR[B]): JSONR[B] = new JSONR[B] {
+      override def read(json: JValue): Result[B] = {
+        fa.read(json) orElse fa2.read(json)
+      }
+    }
+
+  }
+
+  implicit class JSONExt[A](fa: JSON[A]) {
+
+    def xmap[B](f1: A => B, f2: B => A): JSON[B] = new JSON[B] {
+      override def write(value: B): JValue = (fa:JSONW[A]).contramap(f2).write(value)
+
+      override def read(json: JValue): Result[B] = (fa:JSONR[A]).map(f1).read(json)
+    }
+
+    def exmap[B](f1: A => Result[B], f2: B => A): JSON[B] = new JSON[B] {
+      override def write(value: B): JValue = (fa:JSONW[A]).contramap(f2).write(value)
+
+      override def read(json: JValue): Result[B] = (fa:JSONR[A]).emap(f1).read(json)
+    }
+
+  }
+
+  implicit class JSONROps(json: JValue) {
+    def validate[A: JSONR]: ValidationNel[Error, A] = implicitly[JSONR[A]].read(json)
+    def read[A: JSONR]: Error \/ A = implicitly[JSONR[A]].read(json).disjunction.leftMap(_.head)
+  }
+
+  implicit class JSONWOps[A](a: A) {
+    def toJson(implicit w: JSONW[A]): JValue = w.write(a)
+  }
+
 
   def field[A: JSONR](name: String)(json: JValue): Result[A] = json match {
     case JObject(fs) => 

--- a/tests/src/test/scala/org/json4s/scalaz/TupleExample.scala
+++ b/tests/src/test/scala/org/json4s/scalaz/TupleExample.scala
@@ -12,4 +12,19 @@ object TupleExample extends Specification {
     val json = native.JsonParser.parse(""" [1,2,3] """)
     fromJSON[Tuple3[Int, Int, Int]](json) must_== Success(1, 2, 3)
   }
+
+
+  "Parse case class from tuple with xmap" in {
+
+    case class CC(i: Int, s: String)
+
+    implicit val ccJSON = JSON[(Int, String)].xmap[CC](
+      tp => CC(tp._1, tp._2),
+      cc => (cc.i, cc.s)
+    )
+
+    val json = native.JsonParser.parse(""" [1,"foo"] """)
+    fromJSON[CC](json) must_== Success(CC(1, "foo"))
+
+  }
 }

--- a/tests/src/test/scala/org/json4s/scalaz/TupleExample.scala
+++ b/tests/src/test/scala/org/json4s/scalaz/TupleExample.scala
@@ -26,5 +26,11 @@ object TupleExample extends Specification {
     val json = native.JsonParser.parse(""" [1,"foo"] """)
     fromJSON[CC](json) must_== Success(CC(1, "foo"))
 
+
+    val json2 = native.JsonParser.parse(""" [1,2] """)
+    fromJSON[CC](json2) must beLike[Result[CC]] {
+      case Failure(xs) => xs.size must_== 1
+    }
+
   }
 }

--- a/tests/src/test/scala/org/json4s/scalaz/ValidationExample.scala
+++ b/tests/src/test/scala/org/json4s/scalaz/ValidationExample.scala
@@ -49,8 +49,8 @@ object ValidationExample extends Specification {
     }.disjunction
 
     // Valid range is a range having start <= end
-    implicit def rangeJSON: JSONR[Range] = new JSONR[Range] {
-      def read(json: JValue) =
+    implicit def rangeJSON: JSONR[Range] = JSONR.instance[Range] {
+      json =>
         (((field[Int]("s")(json) |@| field[Int]("e")(json))(ascending)).disjunction.join map Range.tupled).validation
     }
 


### PR DESCRIPTION
This PR adds a few things to json4s-scalaz:

  - Helpers to create JSONW (apply, instance) and JSONR (apply, instance, instanceE)
  - Monad[JSONR], Contravariant[JSONW]
  - Combinators emap, xmap, exmap, orElse
