### PR TITLE
Use UTC instead of local timezone when deserializing Joda DateTimes using the default formatter

### DIFF
--- a/core/src/main/scala/org/json4s/DateFormat.scala
+++ b/core/src/main/scala/org/json4s/DateFormat.scala
@@ -1,10 +1,11 @@
 package org.json4s
 
-import java.util.Date
+import java.util.{TimeZone, Date}
 
 /** Conversions between String and Date.
  */
 trait DateFormat {
   def parse(s: String): Option[Date]
   def format(d: Date): String
+  def timezone: TimeZone
 }

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -355,6 +355,8 @@ trait Formats extends Serializable { self: Formats =>
 
       def format(d: Date) = formatter.format(d)
 
+      def timezone = formatter.getTimeZone
+
       private[this] def formatter = df()
     }
 

--- a/examples/src/main/scala/org/json4s/examples/Swagger.scala
+++ b/examples/src/main/scala/org/json4s/examples/Swagger.scala
@@ -1,7 +1,7 @@
 package org.json4s
 package examples
 
-import java.util.{Date => JDate, Locale}
+import java.util.{Date => JDate, TimeZone, Locale}
 import ext.{ JodaTimeSerializers, EnumNameSerializer }
 import org.joda.time._
 import format.ISODateTimeFormat
@@ -101,6 +101,7 @@ object Api {
       } catch {
         case scala.util.control.NonFatal(_) ⇒ None
       }
+      def timezone = TimeZone.getTimeZone("UTC")
     }
   } ++ Seq(
     new EnumNameSerializer(ParamType),

--- a/tests/src/test/scala/org/json4s/ext/JodaTimeSerializerSpec.scala
+++ b/tests/src/test/scala/org/json4s/ext/JodaTimeSerializerSpec.scala
@@ -73,6 +73,7 @@ abstract class JodaTimeSerializerSpec(mod: String) extends Specification {
     "DateTime and DateMidnight use configured date format 2" in {
 
       def usTimeZone = TimeZone.getTimeZone("America/New_York")
+      def usDateTimeZone = forTimeZone(usTimeZone)
 
       implicit val formats = new DefaultFormats {
         override def dateFormatter = {
@@ -83,21 +84,20 @@ abstract class JodaTimeSerializerSpec(mod: String) extends Specification {
         }
       } ++ JodaTimeSerializers.all
 
-      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0, forTimeZone(usTimeZone)), new DateMidnight(2011, 1, 16, forTimeZone(usTimeZone)))
+      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0, usDateTimeZone), new DateMidnight(2011, 1, 16, usDateTimeZone))
       val ser = s.write(x)
       ser must beMatching(
         """\{"dt":"2011-01-16 10:32:00[-+]\d{2}:\d{2}","dm":"2011-01-16 00:00:00[-+]\d{2}:\d{2}"\}""")
 
-      (m.parse(ser) \ "dt").extract[DateTime] must_== new DateTime(2011, 1, 16, 10, 32, 0, 0, forTimeZone(usTimeZone))
-      (m.parse(ser) \ "dm").extract[DateTime] must_== new DateMidnight(2011, 1, 16, forTimeZone(usTimeZone))
+      (m.parse(ser) \ "dt").extract[DateTime] must_== new DateTime(2011, 1, 16, 10, 32, 0, 0, usDateTimeZone)
+      (m.parse(ser) \ "dm").extract[DateTime] must_== new DateMidnight(2011, 1, 16, usDateTimeZone)
     }
 
     "Serialising and deserialising Date types with the default format uses UTC rather than the default local timezone" in {
 
       DateTimeZone.setDefault(DateTimeZone.forID("America/New_York"))
 
-      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0, UTC),
-        new DateMidnight(2011, 1, 16, UTC))
+      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0, UTC), new DateMidnight(2011, 1, 16, UTC))
       val ser = s.write(x)
       val deserialisedDates = s.read[Dates](ser)
 

--- a/tests/src/test/scala/org/json4s/ext/JodaTimeSerializerSpec.scala
+++ b/tests/src/test/scala/org/json4s/ext/JodaTimeSerializerSpec.scala
@@ -17,6 +17,9 @@
 package org.json4s
 package ext
 
+import java.util.TimeZone
+
+import org.joda.time.DateTimeZone.{forTimeZone, UTC}
 import org.joda.time._
 import org.specs2.mutable.Specification
 
@@ -42,9 +45,9 @@ abstract class JodaTimeSerializerSpec(mod: String) extends Specification {
   implicit lazy val formats = s.formats(NoTypeHints) ++ JodaTimeSerializers.all
 
   (mod + " JodaTimeSerializer Specification") should {
-    "Serialize joda time types" in {
+    "Serialize joda time types with default format" in {
       val x = JodaTypes(new Duration(10*1000), new Instant(System.currentTimeMillis),
-                        new DateTime, new DateMidnight, new Interval(1000, 50000),
+                        new DateTime(UTC), new DateMidnight(UTC), new Interval(1000, 50000),
                         new LocalDate(2011, 1, 16), new LocalTime(16, 52, 10), Period.weeks(3))
       val ser = s.write(x)
       s.read[JodaTypes](ser) must_== x
@@ -53,33 +56,52 @@ abstract class JodaTimeSerializerSpec(mod: String) extends Specification {
     "DateTime and DateMidnight use configured date format 1" in {
       implicit val formats = new DefaultFormats {
         override def dateFormatter = {
-          new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss'Z'")
+          val customFormat = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss'Z'")
+          customFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+          customFormat
         }
       } ++ JodaTimeSerializers.all
 
-      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0), new DateMidnight(2011, 1, 16))
+      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0, UTC), new DateMidnight(2011, 1, 16, UTC))
       val ser = s.write(x)
       ser must_== """{"dt":"2011-01-16 10:32:00Z","dm":"2011-01-16 00:00:00Z"}"""
 
-      (m.parse(ser) \ "dt").extract[DateTime] must_== new DateTime(2011, 1, 16, 10, 32, 0, 0)
-      (m.parse(ser) \ "dm").extract[DateTime] must_== new DateMidnight(2011, 1, 16)
+      (m.parse(ser) \ "dt").extract[DateTime] must_== new DateTime(2011, 1, 16, 10, 32, 0, 0, UTC)
+      (m.parse(ser) \ "dm").extract[DateTime] must_== new DateMidnight(2011, 1, 16, UTC)
     }
 
     "DateTime and DateMidnight use configured date format 2" in {
+
+      def usTimeZone = TimeZone.getTimeZone("America/New_York")
+
       implicit val formats = new DefaultFormats {
         override def dateFormatter = {
           // non default format
-          new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ssXXX")
+          val customFormat = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ssXXX")
+          customFormat.setTimeZone(usTimeZone)
+          customFormat
         }
       } ++ JodaTimeSerializers.all
 
-      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0), new DateMidnight(2011, 1, 16))
+      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0, forTimeZone(usTimeZone)), new DateMidnight(2011, 1, 16, forTimeZone(usTimeZone)))
       val ser = s.write(x)
       ser must beMatching(
         """\{"dt":"2011-01-16 10:32:00[-+]\d{2}:\d{2}","dm":"2011-01-16 00:00:00[-+]\d{2}:\d{2}"\}""")
 
-      (m.parse(ser) \ "dt").extract[DateTime] must_== new DateTime(2011, 1, 16, 10, 32, 0, 0)
-      (m.parse(ser) \ "dm").extract[DateTime] must_== new DateMidnight(2011, 1, 16)
+      (m.parse(ser) \ "dt").extract[DateTime] must_== new DateTime(2011, 1, 16, 10, 32, 0, 0, forTimeZone(usTimeZone))
+      (m.parse(ser) \ "dm").extract[DateTime] must_== new DateMidnight(2011, 1, 16, forTimeZone(usTimeZone))
+    }
+
+    "Serialising and deserialising Date types with the default format uses UTC rather than the default local timezone" in {
+
+      DateTimeZone.setDefault(DateTimeZone.forID("America/New_York"))
+
+      val x = Dates(new DateTime(2011, 1, 16, 10, 32, 0, 0, UTC),
+        new DateMidnight(2011, 1, 16, UTC))
+      val ser = s.write(x)
+      val deserialisedDates = s.read[Dates](ser)
+
+      deserialisedDates must_== x
     }
 
     "null is serialized as JSON null" in {


### PR DESCRIPTION
It looks like the intention is that by default any DateTimes get serialized with a UTC timezone. 

However because the deserialized DateTime is converted into an instant then wrapped inside another DateTime (using the constructor that doesn't take a timezone), the original timezone is lost. This behaviour has been causing some of my application unit tests to fail now the UK is in BST.

This change propagates the timezone back from the parser along with the instant so it can be plugged into the DateTime/DateMidnight objects later. I've also added a test case showing the problem.

This change should resolve #346 