### PR TITLE
Make json4s-mongo depend on scala-driver

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -157,7 +157,7 @@ object build extends Build {
      base = file("mongo"),
      settings = json4sSettings ++ Seq(
        libraryDependencies ++= Seq(
-         "org.mongodb" % "mongo-java-driver" % "3.2.1"
+         "org.mongodb.scala" %% "mongo-scala-driver" % "1.1.1"
       )
   )) dependsOn(core % "compile;test->test")
 


### PR DESCRIPTION
Should use the mongo scala driver instead of the java driver.

Maybe even make it a runtime dependency with % "runtime".