### PR TITLE
Convert procedures to methods

### DIFF
--- a/benchmark/src/main/scala/org/json4s/benchmark/Runner.scala
+++ b/benchmark/src/main/scala/org/json4s/benchmark/Runner.scala
@@ -3,7 +3,7 @@ package org.json4s.benchmark
 import com.google.caliper.{ Runner => CaliperRunner}
 
 object Runner {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     CaliperRunner.main(classOf[Json4sBenchmark], args)
   }
 }

--- a/benchmark/src/main/scala/org/json4s/benchmark/SerializationBenchmark.scala
+++ b/benchmark/src/main/scala/org/json4s/benchmark/SerializationBenchmark.scala
@@ -42,7 +42,7 @@ class Json4sBenchmark extends SimpleScalaBenchmark {
 
 
 
-  override def setUp() {
+  override def setUp(): Unit = {
     val c = counter.incrementAndGet()
     project = Project("test"+c, new Date, Some(Language("Scala"+c, 2.75+c)), List(
           Team("QA"+c, List(Employee("John Doe"+c, 5+c), Employee("Mike"+c, 3+c))),

--- a/core/src/main/scala/org/json4s/ParserUtil.scala
+++ b/core/src/main/scala/org/json4s/ParserUtil.scala
@@ -106,8 +106,8 @@ object ParserUtil {
     private[this] var cur = 0 // Pointer which points current parsing location
     private[this] var curSegmentIdx = 0 // Pointer which points current segment
 
-    def mark = { curMark = cur; curMarkSegment = curSegmentIdx }
-    def back = cur = cur-1
+    def mark() = { curMark = cur; curMarkSegment = curSegmentIdx }
+    def back() = cur = cur-1
 
     def next: Char = {
       if (cur == offset && read < 0) {
@@ -149,9 +149,9 @@ object ParserUtil {
 
     def near = new String(segment, (cur-20) max 0, 20 min cur)
 
-    def release = segments.foreach(Segments.release)
+    def release() = segments.foreach(Segments.release)
 
-    private[json4s] def automaticClose = if (closeAutomatically) in.close
+    private[json4s] def automaticClose() = if (closeAutomatically) in.close
 
     private[this] def read = {
       if (offset >= segment.length) {
@@ -179,7 +179,7 @@ object ParserUtil {
     private[this] val maxNumOfSegments = 10000
     private[this] var segmentCount = new AtomicInteger(0)
     private[this] val segments = new ArrayBlockingQueue[Segment](maxNumOfSegments)
-    private[json4s] def clear = segments.clear
+    private[json4s] def clear() = segments.clear
 
     def apply(): Segment = {
       val s = acquire

--- a/core/src/main/scala/org/json4s/json_writers.scala
+++ b/core/src/main/scala/org/json4s/json_writers.scala
@@ -306,7 +306,7 @@ private final class FieldStreamingJsonWriter[T <: JWriter](name: String, isFirst
     new ObjectStreamingJsonWriter(nodes, level + 1, parent, pretty, spaces, formats)
   }
 
-  private[this] def writeName(hasPretty: Boolean) {
+  private[this] def writeName(hasPretty: Boolean): Unit = {
     if (!isFirst) {
       nodes.write(",")
       writePretty()
@@ -418,7 +418,7 @@ private final class ArrayStreamingJsonWriter[T <: JWriter](protected[this] val n
     parent
   }
 
-  private[this] def writeComma() {
+  private[this] def writeComma(): Unit = {
     if (!isFirst) {
       nodes.write(',')
       writePretty()
@@ -547,7 +547,7 @@ private sealed abstract class StreamingJsonWriter[T <: JWriter] extends JsonWrit
     case _ => this
   }
 
-  protected def writePretty(outdent: Int = 0) {
+  protected def writePretty(outdent: Int = 0): Unit = {
     if (pretty) {
       nodes write '\n'
       nodes.write((" " * (level * spaces - outdent)))

--- a/examples/src/main/scala/org/json4s/examples/EmptyValueStrategyExamples.scala
+++ b/examples/src/main/scala/org/json4s/examples/EmptyValueStrategyExamples.scala
@@ -15,14 +15,14 @@ object EmptyValueTreatmentExamples {
 
   private val eventAsCaseClass = EventAsCaseClass("dinner")
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     jacksonWaySkippingNulls
     jacksonWayPreservingNulls
     nativeWaySkippingNulls
     nativeWayPreservingNulls
   }
 
-  def jacksonWaySkippingNulls() {
+  def jacksonWaySkippingNulls(): Unit = {
     import jackson.JsonMethods._
     import jackson.Serialization._
 
@@ -40,7 +40,7 @@ object EmptyValueTreatmentExamples {
     println("\t" + write(eventAsCaseClass)) // = {"eventType":"dinner"}
   }
 
-  def jacksonWayPreservingNulls() {
+  def jacksonWayPreservingNulls(): Unit = {
     import jackson.JsonMethods._
     import jackson.Serialization._
     implicit val formats = jackson.Serialization.formats(NoTypeHints).preservingEmptyValues
@@ -57,7 +57,7 @@ object EmptyValueTreatmentExamples {
     println("\t" + write(eventAsCaseClass)) // = {"eventType":"dinner","duration":null}
   }
 
-  def nativeWaySkippingNulls() {
+  def nativeWaySkippingNulls(): Unit = {
     import native.JsonMethods._
     import native.Serialization._
 
@@ -75,7 +75,7 @@ object EmptyValueTreatmentExamples {
     println("\t" + write(eventAsCaseClass)) // = {"eventType":"dinner"}
   }
 
-  def nativeWayPreservingNulls() {
+  def nativeWayPreservingNulls(): Unit = {
     import native.JsonMethods._
     import native.Serialization._
     implicit val formats = native.Serialization.formats(NoTypeHints).preservingEmptyValues

--- a/examples/src/main/scala/org/json4s/examples/SerBench.scala
+++ b/examples/src/main/scala/org/json4s/examples/SerBench.scala
@@ -53,7 +53,7 @@ object SerBench extends Benchmark {
 
   val mapper = new ObjectMapper()
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     println("## Serialization  ")
 
     val str = project.toString

--- a/jackson/src/main/scala/org/json4s/jackson/JValueSerializer.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JValueSerializer.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.{SerializerProvider, JsonSerializer}
 import com.fasterxml.jackson.core.JsonGenerator
 
 class JValueSerializer extends JsonSerializer[JValue]{
-  def serialize(value: JValue, json: JsonGenerator, provider: SerializerProvider) {
+  def serialize(value: JValue, json: JsonGenerator, provider: SerializerProvider): Unit = {
     if (value == null) {
       json.writeNull()
     } else {

--- a/jackson/src/main/scala/org/json4s/jackson/Json4sScalaModule.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/Json4sScalaModule.scala
@@ -26,7 +26,7 @@ class Json4sScalaModule extends Module {
 
   def version(): Version = Json4sModule.version
 
-  def setupModule(ctxt: SetupContext) {
+  def setupModule(ctxt: SetupContext): Unit = {
     ctxt.addSerializers(JValueSerializerResolver)
     ctxt.addDeserializers(JValueDeserializerResolver)
   }

--- a/jackson/src/main/scala/org/json4s/jackson/Serialization.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/Serialization.scala
@@ -28,7 +28,7 @@ object Serialization extends Serialization {
     out
   }
 
-  def write[A <: AnyRef](a: A, out: OutputStream)(implicit formats: Formats) {
+  def write[A <: AnyRef](a: A, out: OutputStream)(implicit formats: Formats): Unit = {
     JsonMethods.mapper.writeValue(out, Extraction.decompose(a)(formats: Formats))
   }
 

--- a/native/src/main/scala/org/json4s/native/JsonParser.scala
+++ b/native/src/main/scala/org/json4s/native/JsonParser.scala
@@ -152,7 +152,7 @@ object JsonParser {
       case x => x
     }
 
-    def closeBlock(v: Any) {
+    def closeBlock(v: Any): Unit = {
       @inline def toJValue(x: Any) = x match {
         case json: JValue => json
         case scala.util.control.NonFatal(_) => p.fail(s"unexpected field $x")
@@ -171,7 +171,7 @@ object JsonParser {
       }
     }
 
-    def newValue(v: JValue) {
+    def newValue(v: JValue): Unit = {
       vals.peekAny match {
         case (name: String, value) =>
           vals.pop(classOf[JField])
@@ -332,5 +332,4 @@ object JsonParser {
     case object OBJECT extends BlockMode
   }
 
-  
 }

--- a/scalap/src/main/scala/org/json4s/scalap/Memoisable.scala
+++ b/scalap/src/main/scala/org/json4s/scalap/Memoisable.scala
@@ -49,11 +49,8 @@ trait DefaultMemoisable extends Memoisable {
       other
   }
 
-  protected def onSuccess[S, T](key: AnyRef,  result: Success[S, T])  {
+  protected def onSuccess[S, T](key: AnyRef,  result: Success[S, T]): Unit = {
     val Success(out, t) = result
     if(DefaultMemoisable.debug) println(key + " -> " + t + " (" + out + ")")
   }
 }
-
-
-


### PR DESCRIPTION
This PR removes the following warnings:

* Procedure syntax is deprecated
* side-effecting nullary methods are discouraged