### PR TITLE
Preserve allowNull flag across changes to Formats

### DIFF
--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -75,6 +75,7 @@ trait Formats extends Serializable { self: Formats =>
                     wWantsBigDecimal: Boolean = self.wantsBigDecimal,
                     withPrimitives: Set[Type] = self.primitives,
                     wCompanions: List[(Class[_], AnyRef)] = self.companions,
+                    wAllowNull: Boolean = self.allowNull,
                     wStrict: Boolean = self.strictOptionParsing,
                     wAlwaysEscapeUnicode: Boolean = self.alwaysEscapeUnicode,
                     wEmptyValueStrategy: EmptyValueStrategy = self.emptyValueStrategy): Formats =
@@ -90,6 +91,7 @@ trait Formats extends Serializable { self: Formats =>
       override def wantsBigDecimal: Boolean = wWantsBigDecimal
       override def primitives: Set[Type] = withPrimitives
       override def companions: List[(Class[_], AnyRef)] = wCompanions
+      override def allowNull: Boolean = wAllowNull
       override def strictOptionParsing: Boolean = wStrict
       override def alwaysEscapeUnicode: Boolean = wAlwaysEscapeUnicode
       override def emptyValueStrategy: EmptyValueStrategy = wEmptyValueStrategy

--- a/tests/src/test/scala/org/json4s/FormatsBugs.scala
+++ b/tests/src/test/scala/org/json4s/FormatsBugs.scala
@@ -1,0 +1,17 @@
+package org.json4s
+
+import org.specs2.mutable.Specification
+
+class FormatsBugs extends Specification {
+
+  "Formats" should {
+    "retain 'allowNull' setting over updates" in {
+      val f = new DefaultFormats {
+        override val allowNull: Boolean = false
+      }
+      val fModified = f.withBigDecimal
+      fModified.allowNull must beFalse
+    }
+  }
+
+}


### PR DESCRIPTION
Formats: add allowNull to the list of variables copied to the new instance
when Formats is modified
Create test to verify correct behaviour