### PR TITLE
MongoDB ASync driver support

### DIFF
--- a/amongo/src/main/scala/org/json4s/amongo/CustomSerializers.scala
+++ b/amongo/src/main/scala/org/json4s/amongo/CustomSerializers.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 VATBox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.json4s.amongo
+
+import java.util.regex.Pattern
+import java.util.{Date, UUID}
+
+import org.bson.types.ObjectId
+import org.json4s.JsonAST.{JField, JInt, JObject, JString}
+import org.json4s.reflect.TypeInfo
+import org.json4s.{MappingException, _}
+
+/*
+* Provides a way to serialize/de-serialize ObjectIds.
+*
+* Queries for a ObjectId (oid) using the lift-json DSL look like:
+* ("_id" -> ("$oid" -> oid.toString))
+*/
+class ObjectIdSerializer extends Serializer[ObjectId] {
+  private val ObjectIdClass = classOf[ObjectId]
+
+  def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), ObjectId] = {
+    case (TypeInfo(ObjectIdClass, _), json) => json match {
+      case JObject(JField("$oid", JString(s)) :: Nil) if ObjectId.isValid(s) =>
+        new ObjectId(s)
+      case x => throw new MappingException(s"Can't convert $x to ObjectId")
+    }
+  }
+
+  def serialize(implicit formats: Formats): PartialFunction[Any, JValue] = {
+    case x: ObjectId => JObjectSerializer.objectIdAsJValue(x)
+  }
+}
+
+/*
+* Provides a way to serialize/de-serialize Patterns.
+*
+* Queries for a Pattern (pattern) using the lift-json DSL look like:
+* ("pattern" -> (("$regex" -> pattern.pattern) ~ ("$flags" -> pattern.flags)))
+* ("pattern" -> (("$regex" -> "^Mo") ~ ("$flags" -> Pattern.CASE_INSENSITIVE)))
+*/
+class PatternSerializer extends Serializer[Pattern] {
+  private val PatternClass = classOf[Pattern]
+
+  def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Pattern] = {
+    case (TypeInfo(PatternClass, _), json) => json match {
+      case JObject(JField("$regex", JString(s)) :: JField("$flags", JInt(f)) :: Nil) =>
+        Pattern.compile(s, f.intValue)
+      case x => throw new MappingException(s"Can't convert $x to Pattern")
+    }
+  }
+
+  def serialize(implicit formats: Formats): PartialFunction[Any, JValue] = {
+    case x: Pattern => JObjectSerializer.patternAsJValue(x)
+  }
+}
+
+/*
+* Provides a way to serialize/de-serialize Dates.
+*
+* Queries for a Date (dt) using the lift-json DSL look like:
+* ("dt" -> ("$dt" -> formats.dateFormat.format(dt)))
+*/
+class DateSerializer(fieldName: String = "$dt") extends Serializer[Date] {
+  private val DateClass = classOf[Date]
+
+  def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Date] = {
+    case (TypeInfo(DateClass, _), json) => json match {
+      case JObject(JField(`fieldName`, JString(s)) :: Nil) =>
+        format.dateFormat.parse(s).getOrElse(throw new MappingException(s"Can't parse $s to Date"))
+      case x => throw new MappingException(s"Can't convert $x to Date")
+    }
+  }
+
+  def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
+    case d: Date => JObjectSerializer.dateAsJValue(d)
+  }
+}
+
+/*
+* Provides a way to serialize/de-serialize UUIDs.
+*
+* Queries for a UUID (u) using the lift-json DSL look like:
+* ("uuid" -> ("$uuid" -> u.toString))
+*/
+class UUIDSerializer extends Serializer[UUID] {
+  private val UUIDClass = classOf[UUID]
+
+  def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), UUID] = {
+    case (TypeInfo(UUIDClass, _), json) => json match {
+      case JObject(JField("$uuid", JString(s)) :: Nil) => UUID.fromString(s)
+      case x => throw new MappingException(s"Can't convert $x to UUID")
+    }
+  }
+
+  def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
+    case x: UUID => JObjectSerializer.uuidAsJValue(x)
+  }
+}

--- a/amongo/src/main/scala/org/json4s/amongo/JObjectParser.scala
+++ b/amongo/src/main/scala/org/json4s/amongo/JObjectParser.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 VATBox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.json4s.amongo
+
+import java.util.UUID
+import java.util.regex.Pattern
+
+import org.bson._
+import org.bson.codecs.{PatternCodec, UuidCodec}
+import org.bson.types.ObjectId
+import org.json4s.JsonAST._
+import org.json4s.ParserUtil.ParseException
+import org.json4s.{Formats, JValue}
+
+import scala.math.ScalaNumber
+
+case class JObjectParser(optimizeBigInt: Boolean = true) {
+
+  def parse(jv: JValue)(implicit formats: Formats): BsonValue = jv match {
+    case JObject(obj) => parseObject(obj)
+    case JArray(arr) => parseArray(arr)
+    case primitive => throw new ParseException(s"Unable to parse $primitive to BsonValue", null)
+  }
+
+  private def parseObject(obj: List[JField])(implicit formats: Formats): BsonDocument = {
+    val out = new BsonDocument()
+    obj.filterNot { case (_, v) => v == JNothing }.foreach { case (name, jv) =>
+      out.put(name, jValueToBson(jv))
+    }
+    out
+  }
+
+  private def parseArray(arr: List[JValue])(implicit formats: Formats): BsonArray = {
+    val out = new BsonArray()
+    arr.filterNot(_ == JNothing).foreach { jv =>
+      out.add(jValueToBson(jv))
+    }
+    out
+  }
+
+  private def jValueToBson(jValue: JValue)(implicit formats: Formats): BsonValue = jValue match {
+    case JObject(JField("$oid", JString(s)) :: Nil) if ObjectId.isValid(s) =>
+      new BsonObjectId(new ObjectId(s))
+    case JObject(JField("$regex", JString(s)) :: JField("$flags", JInt(f)) :: Nil) =>
+      patternToBson(Pattern.compile(s, f.intValue))
+    case JObject(JField("$dt", JString(s)) :: Nil) =>
+      formats.dateFormat.parse(s).map(date => new BsonDateTime(date.getTime)) match {
+        case Some(bsonDT) => bsonDT
+        case None => throw new ParseException(s"Failed to parse into Date from $s", null)
+      }
+    case JObject(JField("$uuid", JString(s)) :: Nil) =>
+      UUIDtoBson(UUID.fromString(s))
+    case JObject(jvObj) => parseObject(jvObj)
+    case JArray(arr) => parseArray(arr)
+    case primitiveJValue => parseJValue(primitiveJValue)
+  }
+
+  private def parseJValue(jValue: JValue)(implicit formats: Formats): BsonValue = jValue match {
+    case JNothing => sys.error("No BsonValue for 'Nothing'")
+    case JNull => BsonNull.VALUE
+    case JString(s) if s == null => new BsonString("null")
+    case JString(s) => new BsonString(s)
+    case JDouble(num) => new BsonDouble(num)
+    case JLong(num) => new BsonInt64(num)
+    case JBool(value) => new BsonBoolean(value)
+    case JDecimal(num) => bigNumberToBson(num)
+    case JInt(num) => bigNumberToBson(num)
+    case fallback => new BsonString("") // Not quite sure if that's a good thing
+  }
+
+  private def bigNumberToBson(number: ScalaNumber): BsonValue = number match {
+    case bi: BigInt if optimizeBigInt =>
+      if (bi <= Int.MaxValue && bi >= Int.MinValue)
+        new BsonInt32(bi.intValue())
+      else if (bi <= Long.MaxValue && bi >= Long.MinValue) new BsonInt64(bi.longValue())
+      else new BsonString(bi.toString)
+    case bigNum => new BsonString(bigNum.toString)
+  }
+
+  private def patternToBson(pattern: Pattern): BsonValue = {
+    val wrapper = new BsonDocumentWrapper[Pattern](pattern, new PatternCodec)
+    wrapper
+  }
+
+  private def UUIDtoBson(uuid: UUID): BsonValue = {
+    val wrapper = new BsonDocumentWrapper[UUID](uuid, new UuidCodec(UuidRepresentation.STANDARD))
+    wrapper
+  }
+}
+
+object JObjectParser {
+  def parser = JObjectParser()
+}

--- a/amongo/src/main/scala/org/json4s/amongo/JObjectSerializer.scala
+++ b/amongo/src/main/scala/org/json4s/amongo/JObjectSerializer.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 VATBox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.json4s.amongo
+
+import java.util.regex.Pattern
+import java.util.{Calendar, Date, UUID}
+
+import org.bson._
+import org.bson.codecs.UuidCodec
+import org.bson.types.ObjectId
+import org.json4s.JsonAST.JNull
+import org.json4s._
+
+import scala.collection.JavaConversions._
+
+object JObjectSerializer {
+  def serialize(a: Any)(implicit formats: Formats): JValue = {
+    a.asInstanceOf[AnyRef] match {
+      case null => JNull
+      case b: BsonNull => JNull
+      case b: BsonArray => JArray(b.toList.map(serialize))
+      case b: BsonBoolean => JBool(b.getValue)
+      case b: BsonDateTime => dateAsJValue(new Date(b.getValue)) // UTC Epoch [[https://docs.mongodb.com/manual/reference/bson-types/#date]]
+      case b: BsonDocument => JObject(
+        b.entrySet.toList.map(entry => JField(entry.getKey, serialize(entry.getValue)))
+      )
+      case b: BsonBinary if b.getType == BsonBinarySubType.UUID_STANDARD.getValue => uuidAsJValue(binaryUUID(b))
+      case b: BsonDouble => JDouble(b.getValue)
+      case b: BsonInt32 => JInt(BigInt(b.getValue))
+      case b: BsonInt64 => JLong(b.getValue)
+      case b: BsonObjectId if isObjectIdSerializerUsed => objectIdAsJValue(b.getValue)
+      case b: BsonObjectId => JString(b.getValue.toString)
+      case b: BsonString => JString(b.getValue)
+      case x => typeToJValue(x)
+    }
+  }
+
+  /*
+    * This is used to convert DBObjects into JObjects, it's here just in case mongo will decide to return one of these objects
+    */
+  private def typeToJValue(a: Any)(implicit formats: Formats): JValue = a match {
+    case null => JNull
+    case x: String => JString(x)
+    case x: Int => JInt(x)
+    case x: Long => JLong(x)
+    case x: Double => JDouble(x)
+    case x: Float => JDouble(x)
+    case x: Byte => JInt(BigInt(x))
+    case x: BigInt => JInt(x)
+    case x: BigDecimal => JDecimal(x)
+    case x: Boolean => JBool(x)
+    case x: Short => JInt(BigInt(x))
+    case x: java.lang.Integer => JInt(BigInt(x.asInstanceOf[Int]))
+    case x: java.lang.Long => JLong(x)
+    case x: java.lang.Double => JDouble(x.asInstanceOf[Double])
+    case x: java.lang.Float => JDouble(x.asInstanceOf[Float])
+    case x: java.lang.Byte => JInt(BigInt(x.asInstanceOf[Byte]))
+    case x: java.lang.Boolean => JBool(x.asInstanceOf[Boolean])
+    case x: java.lang.Short => JInt(BigInt(x.asInstanceOf[Short]))
+    case x: Calendar => dateAsJValue(x.getTime)
+    case x: Date => dateAsJValue(x)
+    case x: ObjectId if isObjectIdSerializerUsed => objectIdAsJValue(x)
+    case x: ObjectId => JString(x.toString)
+    case x: Pattern => patternAsJValue(x)
+    case x: UUID => uuidAsJValue(x)
+    case _ => JNothing
+  }
+
+  private def binaryUUID(bin: BsonBinary) = {
+    /**
+      * This code was copied from [[UuidCodec]] since no better elegant solution was found
+      */
+    def readLongFromArrayBigEndian(bytes: Array[Byte], offset: Int): Long = {
+      var x: Long = 0
+      x |= (0xFFL & bytes(offset + 7))
+      x |= (0xFFL & bytes(offset + 6)) << 8
+      x |= (0xFFL & bytes(offset + 5)) << 16
+      x |= (0xFFL & bytes(offset + 4)) << 24
+      x |= (0xFFL & bytes(offset + 3)) << 32
+      x |= (0xFFL & bytes(offset + 2)) << 40
+      x |= (0xFFL & bytes(offset + 1)) << 48
+      x |= (0xFFL & bytes(offset)) << 56
+      x
+    }
+    if (bin.getData.length == 16) {
+      new UUID(readLongFromArrayBigEndian(bin.getData,0),readLongFromArrayBigEndian(bin.getData,8))
+    } else throw new BSONException("Unexpected UUID representation")
+
+  }
+
+  private[amongo] def dateAsJValue(d: Date)(implicit formats: Formats) = JObject(JField("$dt", JString(formats.dateFormat.format(d))) :: Nil)
+
+  private[amongo] def patternAsJValue(p: Pattern) = JObject(JField("$regex", JString(p.pattern)) :: JField("$flags", JInt(p.flags)) :: Nil)
+
+  private[amongo] def objectIdAsJValue(oid: ObjectId) = JObject(JField("$oid", JString(oid.toString)) :: Nil)
+
+  private[amongo] def uuidAsJValue(u: UUID): JValue = JObject(JField("$uuid", JString(u.toString)) :: Nil)
+
+  private def isObjectIdSerializerUsed(implicit formats: Formats): Boolean = {
+    formats.customSerializers.exists(_.getClass == classOf[ObjectIdSerializer])
+  }
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -87,7 +87,7 @@ object build extends Build {
     id = "json4s",
     base = file("."),
     settings = json4sSettings ++ noPublish
-  ) aggregate(core, native, json4sExt, jacksonSupport, scalazExt, json4sTests, mongo, ast, scalap, examples, benchmark)
+  ) aggregate(core, native, json4sExt, jacksonSupport, scalazExt, json4sTests, mongo, amongo, ast, scalap, examples, benchmark)
 
   lazy val ast = Project(
     id = "json4s-ast",
@@ -161,6 +161,15 @@ object build extends Build {
       )
   )) dependsOn(core % "compile;test->test")
 
+  lazy val amongo = Project(
+    id = "json4s-amongo",
+    base = file("amongo"),
+    settings = json4sSettings ++ Seq(
+      libraryDependencies ++= Seq(
+        "org.mongodb" % "bson" % "3.2.2"
+      )
+    )) dependsOn (core % "compile;test->test")
+
   lazy val json4sTests = Project(
     id = "json4s-tests",
     base = file("tests"),
@@ -172,7 +181,7 @@ object build extends Build {
           |import reflect._
         """.stripMargin
     ) ++ noPublish
-  ) dependsOn(core, native, json4sExt, scalazExt, jacksonSupport, mongo)
+  ) dependsOn(core, native, json4sExt, scalazExt, jacksonSupport, mongo, amongo)
 
   lazy val benchmark = Project(
     id = "json4s-benchmark",
@@ -190,7 +199,7 @@ object build extends Build {
             runJVMOptions = options, workingDirectory = Some(base)) )
       }
     ) ++ noPublish
-  ) dependsOn(core, native, jacksonSupport, json4sExt, mongo)
+  ) dependsOn(core, native, jacksonSupport, json4sExt, mongo,amongo)
 
 
 }

--- a/tests/src/test/scala/org/json4s/amongo/ParserSpec.scala
+++ b/tests/src/test/scala/org/json4s/amongo/ParserSpec.scala
@@ -1,0 +1,58 @@
+package org.json4s.amongo
+
+import java.util.Date
+
+import org.bson.BsonDocument
+import org.json4s.amongo.gens.Generators
+import org.json4s.amongo.model.{EmbeddedObject, SimpleObject}
+import org.json4s.{DefaultFormats, Extraction}
+import org.scalacheck.Prop
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+object ParserSpec extends Specification with ScalaCheck {
+  implicit val formats = DefaultFormats.lossless + new ObjectIdSerializer + new DateSerializer
+  "New Bson Objects support" should {
+    "Convert simple object into BsonValue and back" ! Prop.forAll(Generators.simpleObjectGen) { simple =>
+      val jValue = Extraction.decompose(simple)
+      val doc: BsonDocument = JObjectParser().parse(jValue).asDocument()
+      val deserialized = JObjectSerializer.serialize(doc)
+      val simpleObjectFromDB = Extraction.extract[SimpleObject](deserialized)
+      simpleObjectFromDB must_== simple
+    }
+
+    "Convert embedded object into BsonValue and back" ! Prop.forAll(Generators.embeddedObjectGen) { emb =>
+      val jValue = Extraction.decompose(emb)
+      val doc = JObjectParser().parse(jValue).asDocument()
+      val deserialized = JObjectSerializer.serialize(doc)
+      val embFromDB = Extraction.extract[EmbeddedObject](deserialized)
+      embFromDB must_== emb
+    }
+
+    "Convert object that contains many different lists" ! Prop.forAll(Generators.embeddedObjectGen) { emb =>
+      val jValue = Extraction.decompose(emb)
+      val doc = JObjectParser().parse(jValue).asDocument()
+      val deserialized = JObjectSerializer.serialize(doc)
+      val embFromDB = Extraction.extract[EmbeddedObject](deserialized)
+      embFromDB must_== emb
+    }
+
+    "Date conversion" in {
+      val date = new Date()
+      val jV = Extraction.decompose("date" -> date)
+      val doc = JObjectParser().parse(jV).asDocument
+      val deserialized = JObjectSerializer.serialize(doc)
+      val pair = Extraction.extract[(String, Date)](deserialized)
+      date.getTime must_== pair._2.getTime
+    }
+
+    /**
+      * As you can see there are no tests for Regex and UUID since both of them are serialized using a BsonWrapperDocument
+      * In that case only when they are written to the DB they are treated properly.
+      *
+      * However I made an integration test that uses MongoDB but I can't commit it
+      * since it will require a DB to exist on the Test machine
+      *
+      */
+  }
+}

--- a/tests/src/test/scala/org/json4s/amongo/gens/Generators.scala
+++ b/tests/src/test/scala/org/json4s/amongo/gens/Generators.scala
@@ -1,0 +1,61 @@
+package org.json4s.amongo.gens
+
+import java.util.Date
+
+import org.bson.types.ObjectId
+import org.json4s.amongo.model.{EmbeddedObject, MultipliedObject, SerializerRequiredObjects, SimpleObject}
+import org.scalacheck.{Arbitrary, Gen}
+
+/**
+  * Created by talg on 09/06/2016.
+  */
+object Generators {
+  def simpleObjectGen = for {
+    s <- Gen.listOfN(10, Gen.alphaNumChar).map(_.mkString)
+    i <- Arbitrary.arbInt.arbitrary
+    l <- Arbitrary.arbLong.arbitrary
+    b <- Arbitrary.arbBool.arbitrary
+    o <- Arbitrary.arbOption[Int](Arbitrary.arbInt).arbitrary
+  } yield SimpleObject(
+    _id = ObjectId.get,
+    string = s,
+    int = i,
+    long = l,
+    boolean = b,
+    nullValue = null,
+    option = o
+  )
+
+  def embeddedObjectGen: Gen[EmbeddedObject] = for {
+    s <- Gen.listOfN(10, Gen.alphaNumChar).map(_.mkString)
+    si <- Gen.option(embeddedObjectGen)
+    l <- Gen.choose(0, 5).flatMap(n => Gen.listOfN(n,Arbitrary.arbInt.arbitrary))
+    aO <- Gen.choose(0, 5).flatMap(n => Gen.listOfN(n,simpleObjectGen))
+  } yield EmbeddedObject(
+    string = s,
+    embd = si,
+    list = l,
+    arrObj = aO
+  )
+
+  def multipliedObject: Gen[MultipliedObject] = for {
+    simpleObjects <- Gen.choose(1,10).flatMap(n => Gen.listOfN(n, simpleObjectGen))
+  } yield MultipliedObject(
+    ids = simpleObjects.map(_._id),
+    strings = simpleObjects.map(_.string),
+    ints = simpleObjects.map(_.int),
+    longs = simpleObjects.map(_.long),
+    booleans = simpleObjects.map(_.boolean),
+    nulls = simpleObjects.map(_.nullValue),
+    options = simpleObjects.map(_.option)
+  )
+
+  def serializerRequiredObjGen = for {
+    d <- Gen.choose(1000,100000).flatMap(n => new Date(System.currentTimeMillis() - n))
+    u <- Gen.uuid
+  } yield SerializerRequiredObjects(
+    _id = ObjectId.get,
+    uuid = u,
+    date = d
+  )
+}

--- a/tests/src/test/scala/org/json4s/amongo/model/SimpleObject.scala
+++ b/tests/src/test/scala/org/json4s/amongo/model/SimpleObject.scala
@@ -1,0 +1,16 @@
+package org.json4s.amongo.model
+
+import java.util.{Date, UUID}
+
+import org.bson.types.ObjectId
+
+/**
+  * Created by talg on 09/06/2016.
+  */
+case class SimpleObject(_id: ObjectId, string: String, int: Int, long: Long, boolean: Boolean, nullValue: AnyRef, option: Option[Int])
+
+case class EmbeddedObject(string: String, embd: Option[EmbeddedObject], list: List[Int], arrObj: List[SimpleObject])
+
+case class MultipliedObject(ids: List[ObjectId], strings: List[String], ints: List[Int], longs: List[Long], booleans: List[Boolean], nulls: List[AnyRef], options: List[Option[Int]])
+
+case class SerializerRequiredObjects(_id: ObjectId, uuid: UUID, date: Date)


### PR DESCRIPTION
Since the new Java Mongo Async driver introduced new types, previous version of mongodb support (aka mongo module) will not work with them. Also it was probably wiser to make a parent project for both mongo and amongo projects and share some code I didn't want to change previous mongo project at all, so there are a few lines of code copied from the old mongo project into new amongo one.
Please note that there are 2 types that can't be deserialized without a DB conversion. Those are Regex and UUID types, both of the are wrapped in a BsonDocumentWrapper class and treated by build in codecs from the bson library. I did write some integration code which I didn't post since it will require MongoDB as test dependency. I will post some examples in a different git project which will include all the integration tests and more examples.