### PR TITLE
Allow removing a given custom Serializer from Formats

### DIFF
--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -140,6 +140,11 @@ trait Formats extends Serializable { self: Formats =>
     copy(wCustomSerializers = newSerializers.foldRight(self.customSerializers)(_ :: _))
 
   /**
+   * Removes the specified custom serializer from this formats.
+   */
+  def - (serializer: Serializer[_]): Formats = copy(wCustomSerializers = self.customSerializers.filterNot(_ == serializer))
+
+  /**
    * Adds the specified custom serializers to this formats.
    */
   def addKeySerializers (newKeySerializers: Traversable[KeySerializer[_]]): Formats =


### PR DESCRIPTION
I've run into this need more than twice:

When deserializing polymorphic data, I often want to write a custom deserializer for a `trait`, that checks for the existence/value of some JSON field, say a field named `type` and based on that information, extracts the value using a specific case class. The problem is that the deserializer ends up calling itself recursively. The most elegant solution I've come up with is adding a `-` method to `Formats` so that you can easily prevent this recursion.

A naive example below.

```scala
trait Animal

case class Cat() extends Animal
case class Dog() extends Animal

object AnimalSerializer extends Serializer[Animal] {
  def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Animal] = {
    case (TypeInfo(c, _), json) if classOf[Animal].isAssignableFrom(c) =>
      extract(json, format) // method extracted to get the "implicit format" out of scope to allow override
  }

  private def extract(json: JValue, f: Formats) = {
    implicit val defaultFormats = (f - AnimalSerializer)
    json match {
      case json: JObject if json \ "type" == JString("cat") => json.extract[Cat]
      case json: JObject if json \ "type" == JString("dog") => json.extract[Dog]
    }
  }

  // ...
}
```

In this example, I could of course change the serializer only to match the exact `Animal` class too, to prevent recursion, but in real-life cases I've run to more complex situations where it's not possible or practical and the addition of the minus method is the most elegant solution.