### PR TITLE
don't extract type hints if the extraction class is not assignable 

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -443,7 +443,7 @@ object Extraction {
 
     private object TypeHint {
       def unapply(fs: List[JField]): Option[(String, List[JField])] =
-        if (formats.typeHints == NoTypeHints) None
+        if (!formats.typeHints.shouldExtractHints(descr.erasure.erasure)) None
         else {
           fs.partition(_._1 == formats.typeHintFieldName) match {
             case (Nil, _) => None

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -227,6 +227,7 @@ trait Formats extends Serializable { self: Formats =>
     @deprecated("Use `containsHint` without `_?` instead", "3.2.0")
     def containsHint_?(clazz: Class[_]): Boolean = containsHint(clazz)
     def containsHint(clazz: Class[_]): Boolean = hints exists (_ isAssignableFrom clazz)
+    def shouldExtractHints(clazz: Class[_]): Boolean = hints exists (clazz isAssignableFrom _)
     def deserialize: PartialFunction[(String, JObject), Any] = Map()
     def serialize: PartialFunction[Any, JObject] = Map()
 
@@ -290,6 +291,7 @@ trait Formats extends Serializable { self: Formats =>
     val hints: List[Class[_]] = Nil
     def hintFor(clazz: Class[_]) = sys.error("NoTypeHints does not provide any type hints.")
     def classFor(hint: String) = None
+    override def shouldExtractHints(clazz: Class[_]) = false
   }
 
   /** Use short class name as a type hint.

--- a/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
+++ b/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
@@ -203,7 +203,10 @@ object ShortTypeHintExamples extends TypeHintExamples {
     native.Serialization.read[Animals](ser) must_== Animals(Nil, Dog("pluto"))
   }
 
-
+  "Deserialization succeeds when a field name matching typeHintFieldName exists" in {
+    val ser = """{"jsonClass":"Dog"}"""
+    native.Serialization.read[NotTypeHint](ser) must_== NotTypeHint("Dog")
+  }
 }
 
 object FullTypeHintExamples extends TypeHintExamples {
@@ -244,6 +247,11 @@ object FullTypeHintExamples extends TypeHintExamples {
     val ser = swrite(pw)
     ser must_== """{"name":"zoltan","bird":{"jsonClass":"org.json4s.Chicken","eggs":3}}"""
     read[PlayerWithBird]("""{"name":"zoltan"}""") must_== pw
+  }
+
+  "Deserialization succeeds when a field name matching typeHintFieldName exists" in {
+    val ser = """{"jsonClass":"org.json4s.Chicken"}"""
+    read[NotTypeHint](ser) must_== NotTypeHint("org.json4s.Chicken")
   }
 }
 
@@ -286,6 +294,8 @@ trait TypeHintExamples extends Specification {
     read[(Animal, Animal)](ser) must_== t
   }
 }
+
+case class NotTypeHint(jsonClass: String)
 
 case class Animals(animals: List[Animal], pet: Animal)
 trait Animal


### PR DESCRIPTION
#364 
don't extract type hints if the extraction class is not assignable from any of the classes in hints list