### PR TITLE
Fixed issue with native parsing of BigInt

### DIFF
--- a/native/src/main/scala/org/json4s/native/JsonMethods.scala
+++ b/native/src/main/scala/org/json4s/native/JsonMethods.scala
@@ -8,10 +8,10 @@ import io.Source
 trait JsonMethods extends org.json4s.JsonMethods[Document] {
 
   def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false, useBigIntForLong: Boolean = true): JValue = in match {
-    case StringInput(s) => JsonParser.parse(s, useBigDecimalForDouble)
-    case ReaderInput(rdr) => JsonParser.parse(rdr, useBigDecimalForDouble)
-    case StreamInput(stream) => JsonParser.parse(Source.fromInputStream(stream).bufferedReader(), useBigDecimalForDouble)
-    case FileInput(file) => JsonParser.parse(Source.fromFile(file).bufferedReader(), useBigDecimalForDouble)
+    case StringInput(s) => JsonParser.parse(s, useBigDecimalForDouble, useBigIntForLong)
+    case ReaderInput(rdr) => JsonParser.parse(rdr, useBigDecimalForDouble = useBigDecimalForDouble, useBigIntForLong = useBigIntForLong)
+    case StreamInput(stream) => JsonParser.parse(Source.fromInputStream(stream).bufferedReader(), useBigDecimalForDouble = useBigDecimalForDouble, useBigIntForLong = useBigIntForLong)
+    case FileInput(file) => JsonParser.parse(Source.fromFile(file).bufferedReader(), useBigDecimalForDouble = useBigDecimalForDouble, useBigIntForLong = useBigIntForLong)
   }
 
   def parseOpt(in: JsonInput, useBigDecimalForDouble: Boolean = false, useBigIntForLong: Boolean = true): Option[JValue] = in match {

--- a/tests/src/test/scala/org/json4s/native/NativeJsonMethodsSpec.scala
+++ b/tests/src/test/scala/org/json4s/native/NativeJsonMethodsSpec.scala
@@ -9,6 +9,35 @@ object NativeJsonMethodsSpec extends Specification {
   import scala.text._
   import JsonMethods._
 
+  "JsonMethods.parse" should {
+
+	  val stringJson = """{"number": 200}"""
+
+    "parse StringInput and produce JInt" in {
+      (parse(stringJson) \ "number") must beAnInstanceOf[JInt]
+    }
+
+    "parse ReaderInput and produce JInt" in {
+      (parse(new java.io.StringReader(stringJson)) \ "number") must beAnInstanceOf[JInt]
+    }
+
+    "parse StreamInput and produce JInt" in {
+      (parse(new java.io.ByteArrayInputStream(stringJson.getBytes)) \ "number") must beAnInstanceOf[JInt]
+    }
+
+    "parse StringInput and produce JLong" in {
+      (parse(stringJson, useBigIntForLong = false) \ "number") must beAnInstanceOf[JLong]
+    }
+
+    "parse ReaderInput and produce JLong" in {
+      (parse(new java.io.StringReader(stringJson), useBigIntForLong = false) \ "number") must beAnInstanceOf[JLong]
+    }
+
+    "parse StreamInput and produce AST using Long" in {
+      (parse(new java.io.ByteArrayInputStream(stringJson.getBytes), useBigIntForLong = false) \ "number") must beAnInstanceOf[JLong]
+    }
+  }
+
   "JsonMethods.write" should {
 
     "produce JSON without empty fields" in {


### PR DESCRIPTION
JsonMethods#parse was not passing on the `useBigIntForLong` value when calling JsonParser.parse.  As a result, parsing an integer value always resulted in a BigInt.  While writing unit tests for the change, I also discovered that `useBigDecimal` was being used in lieu of `closeAutomatically` when parsing a `ReaderInput`.  This PR remedies that issue as well.