### PR TITLE
3.5: addition of null checks to class1/2 when traits (#343)

### DIFF
--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -272,6 +272,8 @@ trait Formats extends Serializable { self: Formats =>
   private[json4s] object ClassDelta {
     def delta(class1: Class[_], class2: Class[_]): Int = {
       if (class1 == class2) 0
+      else if (class1 == null) 1
+      else if (class2 == null) -1
       else if (class1.getInterfaces.contains(class2)) 0
       else if (class2.getInterfaces.contains(class1)) 0
       else if (class1.isAssignableFrom(class2)) {

--- a/tests/src/test/scala/org/json4s/FormatsSpec.scala
+++ b/tests/src/test/scala/org/json4s/FormatsSpec.scala
@@ -18,4 +18,15 @@ class FormatsSpec extends Specification {
       DefaultFormats.isInstanceOf[Serializable] must beTrue
     }
   }
+
+  "ClassDelta NPE Issue#342" should {
+    "Check for null class1 based on recursive call to clazz.getSuperclass" in {
+      ClassDelta.delta(null, classOf[Object]) must be_==(1)
+    }
+    "Check for null class2 based on recursive call to clazz.getSuperclass" in {
+      ClassDelta.delta(classOf[Object], null) must be_==(-1)
+    }
+  }
+
+
 }


### PR DESCRIPTION
Cherry-picking the #343 to 3.5 branch as well.

* addition of null checks to class1/2 when traits
* added NPE check for https://github.com/json4s/json4s/issues/342