### PR TITLE
Added ability to clear the caches

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/Reflector.scala
+++ b/core/src/main/scala/org/json4s/reflect/Reflector.scala
@@ -23,6 +23,14 @@ object Reflector {
         classOf[java.math.BigDecimal], classOf[java.math.BigInteger])
   }
 
+
+  def clearCaches() = {
+    rawClasses.clear()
+    unmangledNames.clear()
+    descriptors.clear()
+    stringTypes.clear()
+  }
+
   def isPrimitive(t: Type, extra: Set[Type] = Set.empty) = (primitives ++ extra) contains t
 
   def scalaTypeOf[T](implicit mf: Manifest[T]): ScalaType = ScalaType(mf)

--- a/core/src/main/scala/org/json4s/reflect/package.scala
+++ b/core/src/main/scala/org/json4s/reflect/package.scala
@@ -42,6 +42,8 @@ package object reflect {
       cache.put(x, v)
       v
     }
+
+    def clear() = cache.clear()
   }
 
   private[reflect] val ConstructorDefault = "$lessinit$greater$default"


### PR DESCRIPTION
When using json4s within PlayFramework, in development mode when a change is made and the classes reload, json4s holds on to the class objects for previously serialised objects. 
This causes a class cast exception e.g.
ClassCastException: com.xxxx.AClass cannot be cast to com.xxxx.AClass

This change added ability to clear caches. This can be invoked when the application reloads