### PR TITLE
Show the error message for parsing UUID

### DIFF
--- a/ext/src/main/scala/org/json4s/ext/JavaTypesSerializers.scala
+++ b/ext/src/main/scala/org/json4s/ext/JavaTypesSerializers.scala
@@ -20,6 +20,7 @@ package ext
 import java.net.URL
 import java.net.URI
 import java.util.UUID
+import scala.util.{Try, Success, Failure}
 
 object JavaTypesSerializers {
   val all = List(UUIDSerializer, URLSerializer, URISerializer)
@@ -27,7 +28,12 @@ object JavaTypesSerializers {
 
 case object UUIDSerializer extends CustomSerializer[UUID](format => (
   {
-    case JString(s) => UUID.fromString(s)
+    case JString(s) =>
+      Try(UUID.fromString(s)) match {
+        case Success(u) => u
+        case Failure(e) =>
+          throw new MappingException(e.getMessage, new java.lang.IllegalArgumentException(e))
+      }
     case JNull      => null
   },
   {

--- a/ext/src/main/scala/org/json4s/ext/JavaTypesSerializers.scala
+++ b/ext/src/main/scala/org/json4s/ext/JavaTypesSerializers.scala
@@ -17,10 +17,10 @@
 package org.json4s
 package ext
 
-import java.net.URL
-import java.net.URI
+import java.net.{URI, URL}
 import java.util.UUID
-import scala.util.{Try, Success, Failure}
+
+import scala.util.control.NonFatal
 
 object JavaTypesSerializers {
   val all = List(UUIDSerializer, URLSerializer, URISerializer)
@@ -29,10 +29,11 @@ object JavaTypesSerializers {
 case object UUIDSerializer extends CustomSerializer[UUID](format => (
   {
     case JString(s) =>
-      Try(UUID.fromString(s)) match {
-        case Success(u) => u
-        case Failure(e) =>
-          throw new MappingException(e.getMessage, new java.lang.IllegalArgumentException(e))
+      try {
+        UUID.fromString(s)
+      } catch {
+        case NonFatal(e) =>
+          throw MappingException(e.getMessage, new java.lang.IllegalArgumentException(e))
       }
     case JNull      => null
   },

--- a/tests/src/test/scala/org/json4s/ext/UUIDSerializerSpec.scala
+++ b/tests/src/test/scala/org/json4s/ext/UUIDSerializerSpec.scala
@@ -43,7 +43,13 @@ abstract class UUIDSerializerSpec(mod: String) extends Specification {
       val ser = s.write(x)
       s.read[SubjectWithUUID](ser) must_== x
     }
+
+    "Throw mapping exceptions when fails to create uuid from string" in {
+      val nonUUIDString = "abcdef"
+      JString(nonUUIDString).extract[UUID] must throwA[MappingException]
+    }
   }
+
 }
 
 case class SubjectWithUUID(id:UUID)


### PR DESCRIPTION
Currently when UUID.fromString fails, the error message on the very top is just Unknown error.
By fixing this, it can show on which column the uuid is malformed.