### PR TITLE
refactors and adds JLong, JDecimal and JSet support to JObjectParser in mongo

### DIFF
--- a/mongo/src/main/scala/org/json4s/mongo/JObjectParser.scala
+++ b/mongo/src/main/scala/org/json4s/mongo/JObjectParser.scala
@@ -40,15 +40,15 @@ object JObjectParser  {
     else s
   }
 
-  /*
-  * Parse a JObject into a DBObject
-  */
+  /**
+    * Parse a JObject into a DBObject
+    */
   def parse(jo: JValue)(implicit formats: Formats): DBObject =
     Parser.parse(jo, formats)
 
-  /*
-  * Serialize a DBObject into a JObject
-  */
+  /**
+    * Serialize a DBObject into a JObject
+    */
   def serialize(a: Any)(implicit formats: Formats): JValue = serialize0(a, formats)
 
   private[this] def serialize0(a: Any, formats: Formats): JValue = {
@@ -58,15 +58,15 @@ object JObjectParser  {
       case x if isPrimitive(x.getClass) => primitive2jvalue(x)
       case x if isDateType(x.getClass) => datetype2jvalue(x)(formats)
       case x if isMongoType(x.getClass) => mongotype2jvalue(x)(formats)
-      case x: BasicDBList => JArray(x.asScala.toList.map( x => serialize0(x, formats)))
-      case x: BasicDBObject => JObject(
-        x.keySet.asScala.toList.map { f =>
-          JField(f.toString, serialize0(x.get(f.toString), formats))
-        }
+      case x: BasicDBList => JArray(
+        x.asScala.toList.map(serialize0(_, formats))
       )
-      case x => {
-        JNothing
-      }
+      case x: BasicDBObject => JObject(
+        x.asScala.map { case (key, value) =>
+          JField(key, serialize0(value, formats))
+        } toList
+      )
+      case _ => JNothing
     }
   }
 

--- a/mongo/src/main/scala/org/json4s/mongo/JObjectParser.scala
+++ b/mongo/src/main/scala/org/json4s/mongo/JObjectParser.scala
@@ -94,8 +94,8 @@ object JObjectParser  {
       case JObject(jo) => Some(parseObject(jo, formats))
       case JBool(b) => Some(java.lang.Boolean.valueOf(b))
       case JInt(n) => Some(renderInteger(n))
-      case JLong(n) => Some(new java.lang.Long(n))
-      case JDouble(n) => Some(new java.lang.Double(n))
+      case JLong(n) => Some(java.lang.Long.valueOf(n))
+      case JDouble(n) => Some(java.lang.Double.valueOf(n))
       case JDecimal(bd) => Some(bd.bigDecimal.toString)
       case JNull => Some(null)
       case JNothing => sys.error("can't render 'nothing'")
@@ -122,12 +122,10 @@ object JObjectParser  {
     // FIXME: This is not ideal.
     private def renderInteger(i: BigInt): Object = {
       if (i <= java.lang.Integer.MAX_VALUE && i >= java.lang.Integer.MIN_VALUE) {
-        new java.lang.Integer(i.intValue)
-      }
-      else if (i <= java.lang.Long.MAX_VALUE && i >= java.lang.Long.MIN_VALUE) {
-        new java.lang.Long(i.longValue)
-      }
-      else {
+        java.lang.Integer.valueOf(i.intValue)
+      } else if (i <= java.lang.Long.MAX_VALUE && i >= java.lang.Long.MIN_VALUE) {
+        java.lang.Long.valueOf(i.longValue)
+      } else {
         i.toString
       }
     }

--- a/mongo/src/main/scala/org/json4s/mongo/JObjectParser.scala
+++ b/mongo/src/main/scala/org/json4s/mongo/JObjectParser.scala
@@ -98,14 +98,14 @@ object JObjectParser  {
       case JDouble(n) => Some(java.lang.Double.valueOf(n))
       case JDecimal(bd) => Some(bd.bigDecimal.toString)
       case JNull => Some(null)
-      case JNothing => sys.error("can't render 'nothing'")
+      case JNothing => None
       case JString(null) => Some("null")
       case JString(s) => Some(stringProcessor.get()(s))
     }
 
     private def parseArray(arr: List[JValue], formats: Formats): BasicDBList = {
       val dbl = new BasicDBList
-      trimArr(arr) foreach { jv =>
+      arr foreach { jv =>
         render(jv, formats).foreach { o => dbl.add(o) }
       }
       dbl
@@ -113,7 +113,7 @@ object JObjectParser  {
 
     private def parseObject(obj: List[JField], formats: Formats): BasicDBObject = {
       val dbo = new BasicDBObject
-      trimObj(obj) foreach { case (name, jv) =>
+      obj foreach { case (name, jv) =>
         render(jv, formats).foreach { o => dbo.put(name, o) }
       }
       dbo
@@ -130,7 +130,5 @@ object JObjectParser  {
       }
     }
 
-    private def trimArr(xs: List[JValue]) = xs.filterNot(_ == JNothing)
-    private def trimObj(xs: List[JField]) = xs.filterNot(_._2 == JNothing)
   }
 }


### PR DESCRIPTION
Old code wildcard matches `JLong` and produces empty string. This version matches all cases and avoids the wildcard pattern.

This version also changes the parsing of `$oid`, `$regex` and `$uuid` objects, ignoring the `JObject` if there is an error. Please confirm if this behaviour is desired.