### PR TITLE
fix JsonMethods.parse interface change #433

### DIFF
--- a/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
@@ -16,6 +16,10 @@ trait JsonMethods extends org.json4s.JsonMethods[JValue] {
   }
   def mapper = _defaultMapper
 
+  def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false): JValue = {
+    parse(in, useBigDecimalForDouble, true)
+  }
+
   def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false, useBigIntForLong: Boolean = true): JValue = {
     var reader = mapper.reader(classOf[JValue])
     if (useBigDecimalForDouble) reader = reader `with` USE_BIG_DECIMAL_FOR_FLOATS


### PR DESCRIPTION
Add the old version interface as parse is very normal useful, it should be backward compatibility.