### PR TITLE
Fix 433

### DIFF
--- a/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
@@ -16,6 +16,10 @@ trait JsonMethods extends org.json4s.JsonMethods[JValue] {
   }
   def mapper = _defaultMapper
 
+  def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false): JValue = {
+    parse(in, useBigDecimalForDouble, true)
+  }
+
   def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false, useBigIntForLong: Boolean = true): JValue = {
     var reader = mapper.reader(classOf[JValue])
     if (useBigDecimalForDouble) reader = reader `with` USE_BIG_DECIMAL_FOR_FLOATS

--- a/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
@@ -16,7 +16,11 @@ trait JsonMethods extends org.json4s.JsonMethods[JValue] {
   }
   def mapper = _defaultMapper
 
-  def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false): JValue = {
+  def parse(in: JsonInput): JValue = {
+    parse(in, false, true)
+  }
+
+  def parse(in: JsonInput, useBigDecimalForDouble: Boolean): JValue = {
     parse(in, useBigDecimalForDouble, true)
   }
 


### PR DESCRIPTION
Fix JsonMethods.parse interface change (433)

Add the old parse interface, when a interface change, it's better to add a new one and reserve the old one as it's build dependents by some other products.

Interface change works for runtime dependent but effects the build dependent.