### PR TITLE
Reflect: use primary c'tor annotation to find primary constructors

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/Executable.scala
+++ b/core/src/main/scala/org/json4s/reflect/Executable.scala
@@ -59,6 +59,14 @@ class Executable private (val method: Method, val constructor: Constructor[_]) {
     else constructor
   }
 
+  def getMarkedAsPrimary(): Boolean = {
+    if (method == null) {
+      constructor.isAnnotationPresent(classOf[PrimaryConstructor])
+    } else {
+      false
+    }
+  }
+
   override def toString =
     if (method != null)
       s"Executable(Method($method))"

--- a/core/src/main/scala/org/json4s/reflect/PrimaryConstructor.java
+++ b/core/src/main/scala/org/json4s/reflect/PrimaryConstructor.java
@@ -1,0 +1,18 @@
+package org.json4s.reflect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the primary constructor that used to get the fields to serialize from the class.
+ *
+ * Marking two constructors or more as primary in the same class will cause the serializer
+ * to throw IllegalArgumentException.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.CONSTRUCTOR)
+public @interface PrimaryConstructor {
+
+}

--- a/core/src/main/scala/org/json4s/reflect/Reflector.scala
+++ b/core/src/main/scala/org/json4s/reflect/Reflector.scala
@@ -159,7 +159,7 @@ object Reflector {
             }
           }
         }
-        ConstructorDescriptor(ctorParams.toSeq, ctor, isPrimary = false)
+        ConstructorDescriptor(ctorParams.toSeq, ctor, isPrimary = ctor.getMarkedAsPrimary())
       }
     }
 

--- a/core/src/main/scala/org/json4s/reflect/descriptors.scala
+++ b/core/src/main/scala/org/json4s/reflect/descriptors.scala
@@ -235,8 +235,20 @@ case class ClassDescriptor(simpleName: String, fullName: String, erasure: ScalaT
   def mostComprehensive: Seq[ConstructorParamDescriptor] = {
     if (_mostComprehensive == null)
       _mostComprehensive =
-        if (constructors.nonEmpty) constructors.sortBy(-_.params.size).headOption.map(_.params).getOrElse(Nil)
-        else Nil
+        if (constructors.nonEmpty) {
+          val primaryCtors = constructors.filter(_.isPrimary)
+
+          if (primaryCtors.length > 1) {
+            throw new IllegalArgumentException(s"Two constructors annotated with PrimaryConstructor in `${fullName}`")
+          }
+
+          primaryCtors.headOption
+            .orElse(constructors.sortBy(-_.params.size).headOption)
+            .map(_.params)
+            .getOrElse(Nil)
+        } else {
+          Nil
+        }
 
     _mostComprehensive
   }


### PR DESCRIPTION
Fixes a bug where a case class had two constructors for backward compatibility, the one had `keyColumn: string` and the other had `keyColumns: seq[String]`. This caused me lots of headaches :disappointed_relieved: until I found the way that serialization works.

I will be really happy if it will be merged, We can also discuss other ways to implement it (I think that Scala have the metadata for finding the primary constructor as oppose to Java reflection).