### PR TITLE
Support Java8 Date & Time API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 dist: precise
-jdk: oraclejdk7
+jdk: oraclejdk8
 scala:
   - 2.10.6
   - 2.11.11

--- a/ext/src/main/scala/org/json4s/ext/ClassSerializer.scala
+++ b/ext/src/main/scala/org/json4s/ext/ClassSerializer.scala
@@ -1,0 +1,24 @@
+package org.json4s.ext
+
+import org.json4s._
+
+trait ClassType[A, B] {
+  def unwrap(b: B)(implicit format: Formats): A
+  def wrap(a: A)(implicit format: Formats): B
+}
+
+case class ClassSerializer[A : Manifest, B : Manifest](t: ClassType[A, B]) extends Serializer[A] {
+  private val Class = implicitly[Manifest[A]].runtimeClass
+
+  def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), A] = {
+    case (TypeInfo(Class, _), json) => json match {
+      case JNull => null.asInstanceOf[A]
+      case xs: JObject if (xs.extractOpt[B].isDefined) => t.unwrap(xs.extract[B])
+      case value => throw new MappingException(s"Can't convert $value to $Class")
+    }
+  }
+
+  def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
+    case a: A if a.asInstanceOf[AnyRef].getClass == Class => Extraction.decompose(t.wrap(a))
+  }
+}

--- a/ext/src/main/scala/org/json4s/ext/DateParser.scala
+++ b/ext/src/main/scala/org/json4s/ext/DateParser.scala
@@ -1,0 +1,17 @@
+package org.json4s.ext
+
+import java.util.TimeZone
+
+import org.json4s.{Formats, MappingException}
+
+object DateParser {
+
+  def parse(s: String, format: Formats): ZonedInstant = {
+    val instant = format.dateFormat.parse(s).map(_.getTime).getOrElse(throw new MappingException(s"Invalid date format $s"))
+    val timezone = format.dateFormat.timezone
+    ZonedInstant(instant, timezone)
+  }
+
+  case class ZonedInstant(val instant: Long, val timezone: TimeZone)
+
+}

--- a/ext/src/main/scala/org/json4s/ext/JavaTimeSerializers.scala
+++ b/ext/src/main/scala/org/json4s/ext/JavaTimeSerializers.scala
@@ -34,9 +34,10 @@ case object JLocalDateTimeSerializer extends CustomSerializer[LocalDateTime](for
     case JNull => null
   },
   {
-    case d: LocalDateTime => JString(format.dateFormat.format(
-      Date.from(d.toInstant(JavaTimeSerializers.getZoneOffset(format.dateFormat.timezone)))
-    ))
+    case d: LocalDateTime =>
+      JString(format.dateFormat.format(
+        Date.from(d.toInstant(JavaTimeSerializers.getZoneOffset(format.dateFormat.timezone)))
+      ))
   }
 ))
 

--- a/ext/src/main/scala/org/json4s/ext/JavaTimeSerializers.scala
+++ b/ext/src/main/scala/org/json4s/ext/JavaTimeSerializers.scala
@@ -1,0 +1,138 @@
+package org.json4s.ext
+
+import java.time._
+import java.util.{ Date, TimeZone }
+
+import org.json4s._
+
+object JavaTimeSerializers {
+
+  def all = List(
+    JLocalDateTimeSerializer,
+    JZonedDateTimeSerializer,
+    JOffsetDateTimeSerializer,
+    JDurationSerializer,
+    JInstantSerializer,
+    JYearSerializer,
+    JLocalDateSerializer(),
+    JLocalTimeSerializer(),
+    JPeriodSerializer(),
+    JYearMonthSerializer(),
+    JMonthDaySerializer()
+  )
+
+  private[ext] def getZoneOffset(timezone: TimeZone): ZoneOffset = {
+    OffsetDateTime.now(timezone.toZoneId).getOffset
+  }
+}
+
+case object JLocalDateTimeSerializer extends CustomSerializer[LocalDateTime](format => (
+  {
+    case JString(s) =>
+      val zonedInstant = DateParser.parse(s, format)
+      LocalDateTime.ofInstant(Instant.ofEpochMilli(zonedInstant.instant), zonedInstant.timezone.toZoneId)
+    case JNull => null
+  },
+  {
+    case d: LocalDateTime => JString(format.dateFormat.format(
+      Date.from(d.toInstant(JavaTimeSerializers.getZoneOffset(format.dateFormat.timezone)))
+    ))
+  }
+))
+
+case object JZonedDateTimeSerializer extends CustomSerializer[ZonedDateTime](format => (
+  {
+    case JString(s) =>
+      val zonedInstant = DateParser.parse(s, format)
+      ZonedDateTime.ofInstant(Instant.ofEpochMilli(zonedInstant.instant), zonedInstant.timezone.toZoneId)
+    case JNull => null
+  },
+  {
+    case d: ZonedDateTime => JString(format.dateFormat.format(Date.from(d.toInstant())))
+  }
+))
+
+case object JOffsetDateTimeSerializer extends CustomSerializer[OffsetDateTime](format => (
+  {
+    case JString(s) =>
+      val zonedInstant = DateParser.parse(s, format)
+      OffsetDateTime.ofInstant(Instant.ofEpochMilli(zonedInstant.instant), zonedInstant.timezone.toZoneId)
+    case JNull => null
+  },
+  {
+    case d: OffsetDateTime => JString(format.dateFormat.format(Date.from(d.toInstant())))
+  }
+))
+
+case object JDurationSerializer extends CustomSerializer[Duration]( format => (
+  {
+    case JInt(d) => Duration.ofMillis(d.toLong)
+    case JNull => null
+  },
+  {
+    case d: Duration => JInt(d.toMillis)
+  }
+))
+
+case object JInstantSerializer extends CustomSerializer[Instant]( format => (
+  {
+    case JInt(d) => Instant.ofEpochMilli(d.toLong)
+    case JNull => null
+  },
+  {
+    case d: Instant => JInt(d.toEpochMilli)
+  }
+))
+
+case object JYearSerializer extends CustomSerializer[Year]( format => (
+  {
+    case JInt(n) => Year.of(n.toInt)
+    case JNull => null
+  },
+  {
+    case y: Year => JInt(y.getValue)
+  }
+))
+
+private[ext] case class _JLocalDate(year: Int, month: Int, day: Int)
+object JLocalDateSerializer {
+  def apply() = new ClassSerializer(new ClassType[LocalDate, _JLocalDate]() {
+    def unwrap(d: _JLocalDate)(implicit format: Formats) = LocalDate.of(d.year, d.month, d.day)
+    def wrap(d: LocalDate)(implicit format: Formats) =
+      _JLocalDate(d.getYear(), d.getMonthValue, d.getDayOfMonth)
+  })
+}
+
+private[ext] case class _JLocalTime(hour: Int, minute: Int, second: Int, millis: Int)
+object JLocalTimeSerializer {
+  def apply() = new ClassSerializer(new ClassType[LocalTime, _JLocalTime]() {
+    def unwrap(t: _JLocalTime)(implicit format: Formats) =
+      LocalTime.of(t.hour, t.minute, t.second, t.millis)
+    def wrap(t: LocalTime)(implicit format: Formats) =
+      _JLocalTime(t.getHour, t.getMinute, t.getSecond, t.getNano)
+  })
+}
+
+private[ext] case class _JPeriod(year: Int, month: Int, day: Int)
+object JPeriodSerializer {
+  def apply() = new ClassSerializer(new ClassType[Period, _JPeriod]() {
+    def unwrap(p: _JPeriod)(implicit format: Formats) = Period.of(p.year, p.month, p.day)
+    def wrap(p: Period)(implicit format: Formats) = _JPeriod(p.getYears, p.getMonths, p.getDays)
+  })
+}
+
+private[ext] case class _JYearMonth(year: Int, month: Int)
+object JYearMonthSerializer {
+  def apply() = new ClassSerializer(new ClassType[YearMonth, _JYearMonth]() {
+    def unwrap(ym: _JYearMonth)(implicit format: Formats) = YearMonth.of(ym.year, ym.month)
+    def wrap(ym: YearMonth)(implicit format: Formats) = _JYearMonth(ym.getYear, ym.getMonthValue)
+  })
+}
+
+private[ext] case class _JMonthDay(month: Int, dayOfMonth: Int)
+object JMonthDaySerializer {
+  def apply() = new ClassSerializer(new ClassType[MonthDay, _JMonthDay]() {
+    def unwrap(md: _JMonthDay)(implicit format: Formats) = MonthDay.of(md.month, md.dayOfMonth)
+    def wrap(md: MonthDay)(implicit format: Formats) = _JMonthDay(md.getMonthValue, md.getDayOfMonth)
+  })
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -73,13 +73,8 @@ object build {
       }
     },
     version := "3.6.0-SNAPSHOT",
-    javacOptions ++= Seq("-target", "1.6", "-source", "1.6"),
-    javaVersionPrefix in javaVersionCheck := Some{
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, scalaMajor)) if scalaMajor <= 11 => "1.7"
-        case _ => "1.8"
-      }
-    },
+    javacOptions ++= Seq("-target", "1.8", "-source", "1.8"),
+    javaVersionPrefix in javaVersionCheck := Some("1.8"),
     parallelExecution in Test := false,
     manifestSetting,
     resolvers ++= Seq(Opts.resolver.sonatypeReleases),

--- a/tests/src/test/scala/org/json4s/ext/JavaTimeSerializersSpec.scala
+++ b/tests/src/test/scala/org/json4s/ext/JavaTimeSerializersSpec.scala
@@ -40,7 +40,9 @@ abstract class JavaDateTimeSerializerSpec(mod: String) extends Specification {
     "LocalDateTime use configured date format" in {
       implicit val formats = new DefaultFormats {
         override def dateFormatter = {
-          new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss'Z'")
+          val f = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss'Z'")
+          f.setTimeZone(DefaultFormats.UTC)
+          f
         }
       } ++ JavaTimeSerializers.all
 

--- a/tests/src/test/scala/org/json4s/ext/JavaTimeSerializersSpec.scala
+++ b/tests/src/test/scala/org/json4s/ext/JavaTimeSerializersSpec.scala
@@ -1,0 +1,70 @@
+package org.json4s.ext
+
+import java.time._
+
+import org.json4s._
+import org.specs2.mutable.Specification
+
+
+object NativeJavaDateTimeSerializerSpec extends JavaDateTimeSerializerSpec("Native") {
+  val s: Serialization = native.Serialization
+}
+
+object JacksonJavaDateTimeSerializerSpec extends JavaDateTimeSerializerSpec("Jackson") {
+  val s: Serialization = jackson.Serialization
+}
+
+/**
+ * System under specification for JavaTimeSerializer.
+ */
+abstract class JavaDateTimeSerializerSpec(mod: String) extends Specification {
+
+  def s: Serialization
+  implicit lazy val formats = s.formats(NoTypeHints) ++ JavaTimeSerializers.all
+
+  (mod + " JavaTimeSerializer Specification") should {
+    "Serialize java time types" in {
+      val x = JavaTypes(Duration.ofDays(1),
+        Instant.ofEpochMilli(1433890789),
+        Year.of(1987),
+        LocalDateTime.of(2015, 6, 23, 14, 34, 29),
+        LocalDate.of(2015, 10, 17),
+        LocalTime.of(15, 13, 34, 123),
+        Period.of(2014, 11, 22),
+        YearMonth.of(1934, 12),
+        MonthDay.of(11, 24))
+      val ser = s.write(x)
+      s.read[JavaTypes](ser) must_== x
+    }
+
+    "LocalDateTime use configured date format" in {
+      implicit val formats = new DefaultFormats {
+        override def dateFormatter = {
+          new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss'Z'")
+        }
+      } ++ JavaTimeSerializers.all
+
+      val x = JavaDates(LocalDateTime.of(2015, 6, 24, 15, 34, 59))
+      val ser = s.write(x)
+      ser must_== """{"ldt":"2015-06-24 15:34:59Z"}"""
+    }
+
+    "null is serialized as JSON null" in {
+      val x = JavaTypes(null, null, null, null, null, null, null, null, null)
+      val ser = s.write(x)
+      s.read[JavaTypes](ser) must_== x
+    }
+  }
+}
+
+case class JavaTypes(duration: Duration,
+  instant: Instant,
+  year: Year,
+  localDateTime: LocalDateTime,
+  localDate: LocalDate,
+  localTime: LocalTime,
+  period: Period,
+  yearMonth: YearMonth,
+  monthDay: MonthDay)
+
+case class JavaDates(ldt: LocalDateTime)


### PR DESCRIPTION
Fixes #477 

Original pull request is #243 and I added following modifications, Thanks to @DanielaSfregola!

- Improved the timezone handling. It makes possible to handle the timezone correctly when the date format is customized.
- Extracted `DateParser` and `ClassSerializer` as an individual class (or object) and made public `ClassType` because they are useful to make new serializers. It's nice if they are able to be used by users.