### PR TITLE
Fixed suppression of type hinted deserialization within unknown typed non-terminals.

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -426,7 +426,7 @@ object Extraction {
     private[this] val typeArg = tpe.typeArgs.head
     private[this] def mkCollection(constructor: Array[_] => Any) = {
       val array: Array[_] = json match {
-        case JArray(arr) => arr.map(extractDetectingNonTerminal(_, typeArg)).toArray
+        case JArray(arr)      => arr.map(extractDetectingNonTerminal(_, typeArg)).toArray
         case JNothing | JNull => Array[AnyRef]()
         case x                => fail("Expected collection but got " + x + " for root " + json + " and mapping " + tpe)
       }

--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -412,7 +412,7 @@ object Extraction {
 
   // if the type args are unknown, these cases will make sure the elements that are non-terminal
   // will have some type information so type hinted data within the nested structure is deserialized properly
-  private def extractDetectingNonTerminal(jvalue: JValue, typeArg: ScalaType)(implicit formats: Formats) = jvalue match {
+  private[this] def extractDetectingNonTerminal(jvalue: JValue, typeArg: ScalaType)(implicit formats: Formats) = jvalue match {
     case subArr: JArray if typeArg.erasure == Manifest.Object.runtimeClass =>
       extract(subArr, Reflector.scalaTypeOf[List[Object]])
     case subObj: JObject if typeArg.erasure == Manifest.Object.runtimeClass && subObj.obj.exists(_._1 == formats.typeHintFieldName) =>

--- a/tests/src/test/scala/org/json4s/native/SerializationBugs.scala
+++ b/tests/src/test/scala/org/json4s/native/SerializationBugs.scala
@@ -2,9 +2,6 @@ package org.json4s
 
 import org.specs2.mutable.Specification
 import java.util.UUID
-
-import org.specs2.matcher.MatchResult
-
 import scala.collection.mutable
 
 object SerializationBugs extends Specification {


### PR DESCRIPTION
We are trying to serialize / deserialize a nested structure which contains heterogeneous json arrays. This works great until one of the arrays contains another array which contains a type hinted type. Then the deserialization fails to recognize the type hinted map and instead turns it into a raw map. I added a fix for this case as well as other similar cases which cause the type hinted deserialization to be suppressed. See the tests for examples.

Error detected against version: 3.5.0