### PR TITLE
add strictArrayExtraction option, closes #198

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,12 +711,40 @@ res0: PersonWithAddresses("joe", Map("address1" -> Address("Bulevard", "Helsinki
                                      "address2" -> Address("Soho", "London")))
 ```
 
-Note that when the extraction of an `Option[_]` fails, the default behavior of `extract` is to return `None`. You can make it fail with a [MappingException] instead; you can override this behavior by using a custom `Formats` object:
+Note that when the extraction of an `Option[_]` fails, the default behavior of `extract` is to return `None`.
+You can make it fail with a [MappingException] by using a custom `Formats` object:
+
+```scala
+val formats: Formats = DefaultFormats.withStrictOptionParsing
+```
+
+or
 
 ```scala
 val formats: Formats = new DefaultFormats {
   override val strictOptionParsing: Boolean = true
 }
+```
+
+Same happens with collections, the default behavior of `extract` is to return an empty instance of the collection.
+You can make it fail with a [MappingException] by using a custom `Formats` object:
+
+```scala
+val formats: Formats = DefaultFormats.withStrictArrayExtraction
+```
+
+or
+
+```scala
+val formats: Formats = new DefaultFormats {
+  override val strictArrayExtraction: Boolean = true
+}
+```
+
+Both these settings (`strictOptionParsing` and `strictArrayExtraction`) can be enabled with
+
+```scala
+val formats: Formats = DefaultFormats.strict
 ```
 
 Serialization

--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -427,7 +427,7 @@ object Extraction {
     private[this] def mkCollection(constructor: Array[_] => Any) = {
       val array: Array[_] = json match {
         case JArray(arr)      => arr.map(extractDetectingNonTerminal(_, typeArg)).toArray
-        case JNothing | JNull => Array[AnyRef]()
+        case JNothing | JNull if !formats.strictArrayExtraction => Array[AnyRef]()
         case x                => fail("Expected collection but got " + x + " for root " + json + " and mapping " + tpe)
       }
 

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -49,6 +49,7 @@ trait Formats extends Serializable { self: Formats =>
   def companions: List[(Class[_], AnyRef)] = Nil
   def allowNull: Boolean = true
   def strictOptionParsing: Boolean = false
+  def strictArrayExtraction: Boolean = false
   def alwaysEscapeUnicode: Boolean = false
 
   /**
@@ -76,7 +77,8 @@ trait Formats extends Serializable { self: Formats =>
                     withPrimitives: Set[Type] = self.primitives,
                     wCompanions: List[(Class[_], AnyRef)] = self.companions,
                     wAllowNull: Boolean = self.allowNull,
-                    wStrict: Boolean = self.strictOptionParsing,
+                    wStrictOptionParsing: Boolean = self.strictOptionParsing,
+                    wStrictArrayExtraction: Boolean = self.strictArrayExtraction,
                     wAlwaysEscapeUnicode: Boolean = self.alwaysEscapeUnicode,
                     wEmptyValueStrategy: EmptyValueStrategy = self.emptyValueStrategy): Formats =
     new Formats {
@@ -92,7 +94,8 @@ trait Formats extends Serializable { self: Formats =>
       override def primitives: Set[Type] = withPrimitives
       override def companions: List[(Class[_], AnyRef)] = wCompanions
       override def allowNull: Boolean = wAllowNull
-      override def strictOptionParsing: Boolean = wStrict
+      override def strictOptionParsing: Boolean = wStrictOptionParsing
+      override def strictArrayExtraction: Boolean = wStrictArrayExtraction
       override def alwaysEscapeUnicode: Boolean = wAlwaysEscapeUnicode
       override def emptyValueStrategy: EmptyValueStrategy = wEmptyValueStrategy
     }
@@ -116,6 +119,14 @@ trait Formats extends Serializable { self: Formats =>
   def withTypeHintFieldName(name: String): Formats = copy(wTypeHintFieldName = name)
 
   def withEscapeUnicode: Formats = copy(wAlwaysEscapeUnicode = true)
+
+  def withStrictOptionParsing: Formats = copy(wStrictOptionParsing = true)
+
+  def withStrictArrayExtraction: Formats = copy(wStrictArrayExtraction = true)
+
+  def strict: Formats = copy(wStrictOptionParsing = true, wStrictArrayExtraction = true)
+
+  def nonStrict: Formats = copy(wStrictOptionParsing = false, wStrictArrayExtraction = false)
 
   /**
    * Adds the specified type hints to this formats.


### PR DESCRIPTION
This is a reincarnation of #312 which should close #198 

new flag is set to `false` by default to keep compatibility. And it doesn't change behavior if the collection argument has a default value

@seratch @xuwei-k please review