### PR TITLE
Reflector: use companion object apply method

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/Reflector.scala
+++ b/core/src/main/scala/org/json4s/reflect/Reflector.scala
@@ -88,7 +88,7 @@ object Reflector {
       val idxes = container.map(_._2.reverse)
       t  match {
         case v: TypeVariable[_] =>
-          val a = owner.typeVars.getOrElse(v, scalaTypeOf(v))
+          val a = owner.typeVars.getOrElse(v.getName, scalaTypeOf(v))
           if (a.erasure == classOf[java.lang.Object]) {
             val r = ScalaSigReader.readConstructor(name, owner, index, ctorParameterNames)
             scalaTypeOf(r)

--- a/core/src/main/scala/org/json4s/reflect/Reflector.scala
+++ b/core/src/main/scala/org/json4s/reflect/Reflector.scala
@@ -119,17 +119,14 @@ object Reflector {
         er.getConstructors.map(new Executable(_))
       }
       val constructorDescriptors = createConstructorDescriptors(ccs)
-      if (constructorDescriptors.isEmpty) {
-        companion = findCompanion(checkCompanionMapping = false)
-        val applyMethods: scala.Array[Method] = companion match {
-          case Some(singletonDescriptor) => {
-            singletonDescriptor.instance.getClass.getMethods.filter { method => method.getName == "apply" && method.getReturnType == er }
-          }
-          case None => scala.Array[Method]()
-        }
-        val applyExecutables = applyMethods.map{ m => new Executable(m) }
-        createConstructorDescriptors(applyExecutables)
-      } else constructorDescriptors
+      companion = findCompanion(checkCompanionMapping = false)
+      val applyMethods: scala.Array[Method] = companion match {
+        case Some(singletonDescriptor) =>
+          singletonDescriptor.instance.getClass.getMethods.filter { method => method.getName == "apply" && method.getReturnType == er }
+        case None => scala.Array[Method]()
+      }
+      val applyExecutables = applyMethods.map{ m => new Executable(m) }
+      constructorDescriptors ++ createConstructorDescriptors(applyExecutables)
     }
 
     def createConstructorDescriptors(ccs: Iterable[Executable]): Seq[ConstructorDescriptor] = {

--- a/core/src/main/scala/org/json4s/reflect/descriptors.scala
+++ b/core/src/main/scala/org/json4s/reflect/descriptors.scala
@@ -75,13 +75,13 @@ object ScalaType {
   }
   private class CopiedScalaType(
                   mf: Manifest[_],
-                  private[this] var _typeVars: Map[TypeVariable[_], ScalaType],
+                  private[this] var _typeVars: Map[String, ScalaType],
                   override val isPrimitive: Boolean) extends ScalaType(mf) {
 
-    override def typeVars: Map[TypeVariable[_], ScalaType] = {
+    override def typeVars: Map[String, ScalaType] = {
       if (_typeVars == null)
         _typeVars = Map.empty ++
-          erasure.getTypeParameters.map(_.asInstanceOf[TypeVariable[_]]).zip(typeArgs)
+          erasure.getTypeParameters.map(_.asInstanceOf[TypeVariable[_]].getName).zip(typeArgs)
       _typeVars
     }
   }
@@ -96,11 +96,11 @@ class ScalaType(private val manifest: Manifest[_]) extends Equals {
     if (erasure.isArray) List(Reflector.scalaTypeOf(erasure.getComponentType)) else Nil
   )
 
-  private[this] var _typeVars: Map[TypeVariable[_], ScalaType] = null
-  def typeVars: Map[TypeVariable[_], ScalaType] = {
+  private[this] var _typeVars: Map[String, ScalaType] = null
+  def typeVars: Map[String, ScalaType] = {
     if (_typeVars == null)
       _typeVars = Map.empty ++
-        erasure.getTypeParameters.map(_.asInstanceOf[TypeVariable[_]]).zip(typeArgs)
+        erasure.getTypeParameters.map(_.asInstanceOf[TypeVariable[_]].getName).zip(typeArgs)
     _typeVars
   }
 
@@ -161,7 +161,7 @@ class ScalaType(private val manifest: Manifest[_]) extends Equals {
     case _ => false
   }
 
-  def copy(erasure: Class[_] = erasure, typeArgs: Seq[ScalaType] = typeArgs, typeVars: Map[TypeVariable[_], ScalaType] = _typeVars): ScalaType = {
+  def copy(erasure: Class[_] = erasure, typeArgs: Seq[ScalaType] = typeArgs, typeVars: Map[String, ScalaType] = _typeVars): ScalaType = {
     /* optimization */
     if (erasure == classOf[Int] || erasure == classOf[java.lang.Integer]) ScalaType.IntType
     else if (erasure == classOf[Long] || erasure == classOf[java.lang.Long]) ScalaType.LongType

--- a/tests/src/test/scala/org/json4s/ExtractionBugs.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionBugs.scala
@@ -112,6 +112,14 @@ object ExtractionBugs {
     override type A = String
   }
 
+  object CaseClassWithCompanion {
+
+    def apply(v: String): CaseClassWithCompanion = CaseClassWithCompanion(v, "Bar")
+
+  }
+
+  case class CaseClassWithCompanion(value: String, other: String)
+
 }
 abstract class ExtractionBugs[T](mod: String) extends Specification with JsonMethods[T] {
 
@@ -232,6 +240,12 @@ abstract class ExtractionBugs[T](mod: String) extends Specification with JsonMet
       lst.add("one")
       lst.add("two")
       json.extract[util.ArrayList[String]] must_== lst
+    }
+
+    "Extraction should be able to call companion object apply method even when c'tors exists" in {
+      val json = parse("""{"v": "Foo"}""")
+      val expected = CaseClassWithCompanion("Foo")
+      json.extract[CaseClassWithCompanion] must_== expected
     }
 
     "Parse 0 as BigDecimal" in {


### PR DESCRIPTION
even when constructors are available.

This is because `companion.apply(...)` in Scala has more power than secondary c'tors.

- [X] Changed `Reflector`
- [X] Added Test

**Maintainers**: I had to change reflector to lookup the type parameters by name and not by instance because the apply method in scala (that is generated for case classes) has different instances of type parameters than those of the class. That means that if someone will create `Foo.apply[A](..)` for `case class Foo[B](..)`, it might not work. I can throw exception in that case, or whatever - Just let me know what you want, if you want this pull request :smile: 
