### PR TITLE
Removed unnecessary type constraint in `native.Serialization.write*`

### DIFF
--- a/native/src/main/scala/org/json4s/native/Serialization.scala
+++ b/native/src/main/scala/org/json4s/native/Serialization.scala
@@ -33,35 +33,35 @@ object Serialization extends Serialization  {
   import java.io.{Reader, StringWriter, Writer}
   /** Serialize to String.
    */
-  def write[A <: AnyRef](a: A)(implicit formats: Formats): String = {
+  def write[A](a: A)(implicit formats: Formats): String = {
     (write(a, new StringWriter)(formats)).toString
   }
 
   /** Serialize to Writer.
    */
-  def write[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
+  def write[A, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
     Extraction.decomposeWithBuilder(a, JsonWriter.streaming(out)(formats))(formats)
   }
 
   /** Serialize to String (pretty format).
    */
-  def writePretty[A <: AnyRef](a: A)(implicit formats: Formats): String =
+  def writePretty[A](a: A)(implicit formats: Formats): String =
     (writePretty(a, new StringWriter)(formats)).toString
 
   /** Serialize to Writer (pretty format).
    */
-  def writePretty[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
+  def writePretty[A, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
     Extraction.decomposeWithBuilder(a, JsonWriter.streamingPretty(out)(formats))(formats)
   }
 
   /** Serialize to String (pretty format).
    */
-  def writePrettyOld[A <: AnyRef](a: A)(implicit formats: Formats): String =
+  def writePrettyOld[A](a: A)(implicit formats: Formats): String =
     (writePrettyOld(a, new StringWriter)(formats)).toString
 
   /** Serialize to Writer (pretty format).
    */
-  def writePrettyOld[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
+  def writePrettyOld[A, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
     Printer.pretty(JsonMethods.render(Extraction.decompose(a)(formats)), out)
   }
 


### PR DESCRIPTION
`Extraction.decomposeWithBuilder` is defined as follows:
```scala
  def decomposeWithBuilder[T](a: Any, builder: JsonWriter[T])(implicit formats: Formats): T
```
and thus does not require `a` to be an `AnyRef`. The requirement of `write[A <: AnyRef]` breaks the serialisation of primitive values, like `Int`, which should be able to be written with a `writer` like so:

```scala
import org.json4s.DefaultFormats
import org.json4s.native.Serialization.write

implicit val formats = DefaultFormats

write(15)
```