### PR TITLE
fixes serialization issues with using multiple enum serializers

### DIFF
--- a/ext/src/main/scala/org/json4s/ext/EnumSerializer.scala
+++ b/ext/src/main/scala/org/json4s/ext/EnumSerializer.scala
@@ -26,7 +26,7 @@ class EnumSerializer[E <: Enumeration: ClassTag](enum: E)
   val EnumerationClass = classOf[E#Value]
 
   private[this] def isValid(json: JValue) = json match {
-    case JInt(value) => value <= enum.maxId
+    case JInt(value) => enum.values.map(_.id).contains(value.toInt)
     case _ => false
   }
 
@@ -39,7 +39,7 @@ class EnumSerializer[E <: Enumeration: ClassTag](enum: E)
     }
 
   def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
-    case i: E#Value => i.id
+    case i: E#Value if enum.values.exists(_ == i) => i.id
   }
 }
 
@@ -65,6 +65,6 @@ class EnumNameSerializer[E <: Enumeration: ClassTag](enum: E)
   }
 
   def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
-    case i: E#Value => i.toString
+    case i: E#Value if enum.values.exists(_ == i) => i.toString
   }
 }

--- a/tests/src/test/scala/org/json4s/ext/EnumNameSerializerSpec.scala
+++ b/tests/src/test/scala/org/json4s/ext/EnumNameSerializerSpec.scala
@@ -7,36 +7,145 @@ object EnumNameSerializerSpec extends native.JsonMethods {
 
   object Days extends Enumeration {
     type Day = Value
-    val Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday = Value
+    val Monday = Value(1)
+    val Tuesday = Value(2)
+    val Wednesday = Value(3)
+    val Thursday = Value(4)
+    val Friday = Value(5)
+    val Saturday = Value(6)
+    val Sunday = Value(7)
   }
 
   object Weekend extends Enumeration {
     type Weekend = Value
-    val Saturday, Sunday = Value
+    val Saturday = Value(6)
+    val Sunday = Value(7)
   }
 
   object Week extends Enumeration {
     type Week = Value
-    val Monday, Tuesday, Wednesday, Thursday, Friday = Value
+    val Monday = Value(1)
+    val Tuesday = Value(2)
+    val Wednesday = Value(3)
+    val Thursday = Value(4)
+    val Friday = Value(5)
   }
 
-  implicit val formats: Formats =
-    DefaultFormats + new EnumNameSerializer(Days) + new EnumNameSerializer(Weekend) + new EnumNameSerializer(Week)
 }
+
 class EnumNameSerializerSpec extends Specification {
-
   import EnumNameSerializerSpec._
-  val weekdays = JArray("Monday, Tuesday, Wednesday, Thursday, Friday".split(",").map(s => JString(s.trim)).toList)
-  val weekend = JArray("Saturday, Sunday".split(",").map(s => JString(s.trim)).toList)
-  val week = JArray("Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday".split(",").map(s => JString(s.trim)).toList)
 
-  "An enum name serializer" should {
-    "deserialize week days" in {
-      weekdays.extract[List[Week.Week]] must_== List(Week.Monday, Week.Tuesday, Week.Wednesday, Week.Thursday, Week.Friday)
+  val weekdays = List(Week.Monday, Week.Tuesday, Week.Wednesday, Week.Thursday, Week.Friday)
+  val weekend = List(Weekend.Saturday, Weekend.Sunday)
+
+  val weekdayNames = JArray(weekdays.map(s => JString(s.toString)))
+  val weekendNames = JArray(weekend.map(s => JString(s.toString)))
+
+  val weekdayIds = JArray(weekdays.map(s => JInt(s.id)))
+  val weekendIds = JArray(weekend.map(s => JInt(s.id)))
+
+  "An enum serializer" should {
+
+    "serialize with name" in {
+      implicit val formats: Formats =
+        DefaultFormats + new EnumNameSerializer(Days) + new EnumNameSerializer(Weekend) + new EnumNameSerializer(Week)
+      "week days" in {
+        Extraction.decompose(weekdays) must_== weekdayNames
+      }
+
+      "weekend" in {
+        Extraction.decompose(weekend) must_== weekendNames
+      }
     }
 
-    "deserialize weekend" in {
-      weekend.extract[List[Weekend.Weekend]] must_== List(Weekend.Saturday, Weekend.Sunday)
+
+    "deserialize from name" in {
+      implicit val formats: Formats =
+        DefaultFormats + new EnumNameSerializer(Days) + new EnumNameSerializer(Weekend) + new EnumNameSerializer(Week)
+      "week days" in {
+        weekdayNames.extract[List[Week.Week]] must_== weekdays
+      }
+
+      "weekend" in {
+        weekendNames.extract[List[Weekend.Weekend]] must_== weekend
+      }
+    }
+
+    "serialize with id" in {
+      implicit val formats: Formats =
+        DefaultFormats + new EnumSerializer(Days) + new EnumSerializer(Weekend) + new EnumSerializer(Week)
+      "week days" in {
+        Extraction.decompose(weekdays) must_== weekdayIds
+      }
+
+      "weekend" in {
+        Extraction.decompose(weekend) must_== weekendIds
+      }
+    }
+
+    "deserialize from id" in {
+      implicit val formats: Formats =
+        DefaultFormats + new EnumSerializer(Days) + new EnumSerializer(Weekend) + new EnumSerializer(Week)
+      "week days" in {
+        weekdayIds.extract[List[Week.Week]] must_== weekdays
+      }
+
+      "weekend" in {
+        weekendIds.extract[List[Weekend.Weekend]] must_== weekend
+      }
+    }
+
+    "serialize with mix of id and name" in {
+      implicit val formats: Formats =
+        DefaultFormats  + new EnumNameSerializer(Week) + new EnumSerializer(Weekend)
+
+      "week days as names" in {
+        Extraction.decompose(weekdays) must_== weekdayNames
+      }
+
+      "weekends as ids" in {
+        Extraction.decompose(weekend) must_== weekendIds
+      }
+    }
+
+    "serialize with mix of id and name - inverted order of serializers in formats" in {
+      implicit val formats: Formats =
+        DefaultFormats  + new EnumSerializer(Weekend) + new EnumNameSerializer(Week)
+
+      "week days as names" in {
+        Extraction.decompose(weekdays) must_== weekdayNames
+      }
+
+      "weekends as ids" in {
+        Extraction.decompose(weekend) must_== weekendIds
+      }
+    }
+
+    "deserialize with mix of id and name" in {
+      implicit val formats: Formats =
+        DefaultFormats  + new EnumNameSerializer(Week) + new EnumSerializer(Weekend)
+
+      "week days as names" in {
+        weekdayNames.extract[List[Week.Week]] == weekdays
+      }
+
+      "weekends as ids" in {
+        weekendIds.extract[List[Weekend.Weekend]] == weekend
+      }
+    }
+
+    "deserialize with mix of id and name - inverted order of serializers in formats" in {
+      implicit val formats: Formats =
+        DefaultFormats  + new EnumSerializer(Weekend) + new EnumNameSerializer(Week)
+
+      "week days as names" in {
+        weekdayNames.extract[List[Week.Week]] == weekdays
+      }
+
+      "weekends as ids" in {
+        weekendIds.extract[List[Weekend.Weekend]] == weekend
+      }
     }
 
   }


### PR DESCRIPTION
This commit fixes serialization issues with using multiple enum serializers. However, deserialization issues are a bit trickier to address, and this commit won't fix them.

Also, added more test coverage to EnumNameSerializerSpec (which could possibly be now renamed to EnumSerializerSpec as it tests both EnumNameSerializer and EnumSerializer)

Fixes defect #510 and partially fixes (only the serialization side, not deserialization) #5 , #110 , #142 

