### PR TITLE
Use custom serialize for null as None to optionals

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -544,7 +544,10 @@ object Extraction {
           else x
         } catch {
           case e @ MappingException(msg, _) =>
-            if (descr.isOptional  && !formats.strictOptionParsing) defv(None) else fail("No usable value for " + descr.name + "\n" + msg, e)
+            if (descr.isOptional &&
+                (!formats.strictOptionParsing || extract(json, ScalaType[Null](implicitly)) == null))
+              defv(None)
+            else fail("No usable value for " + descr.name + "\n" + msg, e)
         }
       }
     }

--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -355,6 +355,17 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
       parse("""{"name":null,"age":22}""").extract[OChild](notNullFormats, Manifest.classType(classOf[OChild])) must_== new OChild(None, 22, None, None)
     }
 
+    "allowNull format set to false should use custom null serializer to set Option[T] as None" in {
+      object CustomNull extends CustomSerializer[Null](_ => ( {
+        case JNothing => null
+        case JNull => null
+        case JString("") => null
+      }, {
+        case _ => JString("")
+      }))
+      parse("""{"name":null,"age":22, "mother": ""}""").extract[OChild](notNullFormats + CustomNull, Manifest.classType(classOf[OChild])) must_== new OChild(None, 22, None, None)
+    }
+
     "simple case objects should be sucessfully extracted as a singleton instance" in {
       parse(emptyTree).extract[LeafTree[Int]](treeFormats, Manifest.classType(classOf[LeafTree[Int]])) must_== LeafTree.empty
     }


### PR DESCRIPTION
When using a custom serializer for Null values, values marked as Optional did not use the serializer to see if a value is null.
With this patch, json4s will accept values that are handled by the serializer as nulls as a valid value for optionals as None. See the supplied example inside the Extractor spec.