### PR TITLE
avoid ArraySeq. prepare Scala 2.13.0-M4

### DIFF
--- a/scalap/src/main/scala/org/json4s/scalap/SeqRule.scala
+++ b/scalap/src/main/scala/org/json4s/scalap/SeqRule.scala
@@ -82,20 +82,18 @@ class SeqRule[S, +A, +X](rule: Rule[S, S, A, X]) {
 
   /** Repeats this rule num times */
   def times(num: Int): Rule[S, S, Seq[A], X] = from[S] {
-    val result = new scala.collection.mutable.ArraySeq[A](num)
     // more compact using HoF but written this way so it's tail-recursive
-    def rep(i: Int, in: S): Result[S, Seq[A], X] = {
-      if (i == num) Success(in, result)
+    def rep(result: List[A], i: Int, in: S): Result[S, Seq[A], X] = {
+      if (i == num) Success(in, result.reverse)
       else rule(in) match {
        case Success(out, a) => {
-         result(i) = a
-         rep(i + 1, out)
+         rep(a :: result, i + 1, out)
        }
        case Failure => Failure
        case err: Error[_] => err
       }
     }
-    in => rep(0, in)
+    in => rep(Nil, 0, in)
   }
 }
 


### PR DESCRIPTION
- https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1094/consoleFull
- https://github.com/json4s/json4s/issues/515

```
[json4s] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.12/project-builds/json4s-f2930f7846f92e38ab7cbebafe095641764e34fc/scalap/src/main/scala/org/json4s/scalap/SeqRule.scala:85: class WrappedArray is abstract; cannot be instantiated
[json4s] [error]     val result = new scala.collection.mutable.ArraySeq[A](num)
[json4s] [error]                  ^
```