### PR TITLE
Issue#537 Deserialization of default values fails if one list has a default value

### DIFF
--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -398,6 +398,12 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
       parse("""{"values":[{"name":"Bob","gender":"male"}]}""").extract[WithDefaultValueHolder](
         DefaultFormats, Manifest.classType(classOf[WithDefaultValueHolder])) must_== (res)
     }
+
+    "#537 Example with a Seq and default Seq value should be extracted from empty json" in {
+      val res = SeqWithDefaultSeq(values = Nil)
+      parse("""{ }""").extract[SeqWithDefaultSeq] must_== res
+    }
+
   }
 
   val testJson =
@@ -576,6 +582,8 @@ case object EmptyLeaf extends LeafTree[Nothing]
 
 case class WithDefaultValueHolder(values: Seq[WithDefaultValue])
 case class WithDefaultValue(name: String, gender: String = "male")
+
+case class SeqWithDefaultSeq(values:Seq[String], values2:Seq[String] = Seq("1", "2", "3"))
 
 case class Pair(a: String, b: String)
 


### PR DESCRIPTION
I changed the way the constructor is selected. If we have a case class, by default it has two constructors, the normal constructor and the companion apply.

Default values only exists where they are declared, so if apply is selected as constructor, default values don't work.

Now, in case of draw (both of them, normal constructor and apply have the same arguments), it chosees the constructor with more defaults (case class constructor over apply constructor).

I reproduced this issue in case classes with the following format (Seq, Seq = default, any number of Seq or Option with defaults or not)

