### PR TITLE
replaced deprecated jackson method

### DIFF
--- a/jackson/src/main/scala/org/json4s/jackson/JValueDeserializer.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JValueDeserializer.scala
@@ -47,10 +47,10 @@ class JValueDeserializer(klass: Class[_]) extends JsonDeserializer[Object] {
         }
         JObject(fields.toList)
 
-      case _ => throw ctxt.mappingException(classOf[JValue])
+      case _ => ctxt.handleUnexpectedToken(classOf[JValue], jp)
     }
 
-    if (!klass.isAssignableFrom(value.getClass)) throw ctxt.mappingException(klass)
+    if (!klass.isAssignableFrom(value.getClass)) ctxt.handleUnexpectedToken(klass, jp)
 
     value
   }

--- a/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
@@ -17,7 +17,7 @@ trait JsonMethods extends org.json4s.JsonMethods[JValue] {
   def mapper = _defaultMapper
 
   def parse(in: JsonInput, useBigDecimalForDouble: Boolean = false, useBigIntForLong: Boolean = true): JValue = {
-    var reader = mapper.reader(classOf[JValue])
+    var reader = mapper.readerFor(classOf[JValue])
     if (useBigDecimalForDouble) reader = reader `with` USE_BIG_DECIMAL_FOR_FLOATS
     if (useBigIntForLong) reader = reader `with` USE_BIG_INTEGER_FOR_INTS
 


### PR DESCRIPTION
mappingException method is deprecated since 2.9
reader(Class<?> type) method is deprecated since 2.5