### PR TITLE
#545 add underscore camel case keys only

### DIFF
--- a/core/src/main/scala/org/json4s/MonadicJValue.scala
+++ b/core/src/main/scala/org/json4s/MonadicJValue.scala
@@ -380,15 +380,19 @@ class MonadicJValue(jv: JValue) {
     (lst.headOption.map(s ⇒ s.substring(0, 1).toUpperCase(ENGLISH) + s.substring(1)).get ::
       lst.tail.map(s ⇒ s.substring(0, 1).toUpperCase + s.substring(1))).mkString("")
   }
-  private[this] def underscore(word: String): String = {
-    val spacesPattern = "[-\\s]".r
+  private[this] def underscoreCamelCasesOnly(word: String): String = {
     val firstPattern = "([A-Z]+)([A-Z][a-z])".r
     val secondPattern = "([a-z\\d])([A-Z])".r
     val replacementPattern = "$1_$2"
-    spacesPattern.replaceAllIn(
-      secondPattern.replaceAllIn(
-        firstPattern.replaceAllIn(
-          word, replacementPattern), replacementPattern), "_").toLowerCase
+    secondPattern
+      .replaceAllIn(
+        firstPattern.replaceAllIn(word, replacementPattern),
+        replacementPattern
+      ).toLowerCase
+  }
+  private[this] def underscore(word: String): String = {
+    val spacesPattern = "[-\\s]".r
+    spacesPattern.replaceAllIn(underscoreCamelCasesOnly(word), "_")
   }
 
   /**
@@ -406,6 +410,11 @@ class MonadicJValue(jv: JValue) {
    */
   def snakizeKeys: JValue = rewriteJsonAST(this.underscore)
 
+
+  /**
+    * Underscore the camel cased only keys in this [[org.json4s.JsonAST.JValue]]
+    */
+  def underscoreCamelCaseKeysOnly = rewriteJsonAST(underscoreCamelCasesOnly)
 
   /**
    * Underscore all the keys in this org.json4s.JsonAST.JValue

--- a/tests/src/test/scala/org/json4s/Examples.scala
+++ b/tests/src/test/scala/org/json4s/Examples.scala
@@ -336,6 +336,17 @@ abstract class Examples[T](mod: String) extends Specification with JsonMethods[T
       actual must_== expected
     }
 
+    "#545 snake support with case classes and uuid keys" in {
+      implicit val f = DefaultFormats
+      val caseClass = Issue545CamelCaseClassWithUUID(Map("565b2803-fdb9-4359-8c39-da1a347d76ca" -> "awesome"))
+      val expected = """{"my_map":{"565b2803-fdb9-4359-8c39-da1a347d76ca":"awesome"}}"""
+      val unexpected = """{"my_map":{"565b2803_fdb9_4359_8c39_da1a347d76ca":"awesome"}}"""
+      val future = compact(render(Extraction.decompose(caseClass).underscoreCamelCaseKeysOnly))
+      val actual = compact(render(Extraction.decompose(caseClass).underscoreKeys))
+      actual must_== unexpected
+      future must_== expected
+    }
+
     "Camelize should not fail on json with empty keys." in {
       implicit val f = DefaultFormats
       val json = """{"full_name": "Kazuhiro Sera", "github_account_name": "seratch", "" : ""}"""
@@ -345,4 +356,5 @@ abstract class Examples[T](mod: String) extends Specification with JsonMethods[T
     }
   }
 }
+private case class Issue545CamelCaseClassWithUUID(myMap: Map[String, String])
 private case class Issue146CamelCaseClass(fullName: String, githubAccountName: Option[String])


### PR DESCRIPTION
UnderscoreKeys which is also snakizeKeys It's working well until I want to transform class which have fields written with camel case and map where the key is UUID. I don't want to transform this `565b2803-fdb9-4359-8c39-da1a347d76ca` into that `565b2803_fdb9_4359_8c39_da1a347d76ca`.

This PR adds new function `underscoreCamelCaseKeysOnly` which rewrite AST only for camel case keys.

Issue was described here https://github.com/json4s/json4s/issues/545