### PR TITLE
Enhancement: Fail when attempting to deserialize value to undefined property on target class

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -16,11 +16,10 @@
 
 package org.json4s
 
-import java.lang.{Boolean => JavaBoolean, Byte => JavaByte, Double => JavaDouble, Float => JavaFloat, Integer => JavaInteger, Long => JavaLong, Short => JavaShort}
+import java.lang.{Integer => JavaInteger, Long => JavaLong, Short => JavaShort, Byte => JavaByte, Boolean => JavaBoolean, Double => JavaDouble, Float => JavaFloat}
 import java.math.{BigDecimal => JavaBigDecimal}
 import java.util.Date
 import java.sql.Timestamp
-import org.json4s
 import reflect._
 import scala.reflect.Manifest
 import scala.reflect.NameTransformer.encode
@@ -543,7 +542,7 @@ object Extraction {
 
             val setOfDeserializableFields: Set[String] = descr.properties.map(_.name).toSet
 
-            maybeRenamedFields.getOrElse(fields).foreach { case (propName: String, propValue: json4s.JValue) =>
+            maybeRenamedFields.getOrElse(fields).foreach { case (propName: String, propValue: JValue) =>
               if(!setOfDeserializableFields.contains(propName)){
                 throw new RuntimeException(s"Attempted to deserialize JField ${propName} into undefined property on target ClassDescriptor.")
               }

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -51,6 +51,7 @@ trait Formats extends Serializable { self: Formats =>
   def strictOptionParsing: Boolean = false
   def strictArrayExtraction: Boolean = false
   def alwaysEscapeUnicode: Boolean = false
+  def strictFieldDeserialization: Boolean = false
 
   /**
    * The name of the field in JSON where type hints are added (jsonClass by default)
@@ -80,7 +81,8 @@ trait Formats extends Serializable { self: Formats =>
                     wStrictOptionParsing: Boolean = self.strictOptionParsing,
                     wStrictArrayExtraction: Boolean = self.strictArrayExtraction,
                     wAlwaysEscapeUnicode: Boolean = self.alwaysEscapeUnicode,
-                    wEmptyValueStrategy: EmptyValueStrategy = self.emptyValueStrategy): Formats =
+                    wEmptyValueStrategy: EmptyValueStrategy = self.emptyValueStrategy,
+                    wStrictFieldDeserialization: Boolean = self.strictFieldDeserialization): Formats =
     new Formats {
       def dateFormat: DateFormat = wDateFormat
       override def typeHintFieldName: String = wTypeHintFieldName
@@ -98,6 +100,7 @@ trait Formats extends Serializable { self: Formats =>
       override def strictArrayExtraction: Boolean = wStrictArrayExtraction
       override def alwaysEscapeUnicode: Boolean = wAlwaysEscapeUnicode
       override def emptyValueStrategy: EmptyValueStrategy = wEmptyValueStrategy
+      override def strictFieldDeserialization: Boolean = wStrictFieldDeserialization
     }
 
   def withBigInt: Formats = copy(wWantsBigInt = true)
@@ -129,6 +132,8 @@ trait Formats extends Serializable { self: Formats =>
   def nonStrict: Formats = copy(wStrictOptionParsing = false, wStrictArrayExtraction = false)
   
   def disallowNull: Formats = copy(wAllowNull = false)
+
+  def withStrictFieldDeserialization: Formats = copy(wStrictFieldDeserialization = true)
 
   /**
    * Adds the specified type hints to this formats.
@@ -367,6 +372,8 @@ trait DefaultFormats extends Formats {
   override val strictOptionParsing: Boolean = false
   override val emptyValueStrategy: EmptyValueStrategy = EmptyValueStrategy.default
   override val allowNull: Boolean = true
+  override def strictFieldDeserialization: Boolean = false
+
 
   val dateFormat: DateFormat = new DateFormat {
     def parse(s: String) = try {

--- a/tests/src/test/scala/org/json4s/native/FieldSerializerExamples.scala
+++ b/tests/src/test/scala/org/json4s/native/FieldSerializerExamples.scala
@@ -91,7 +91,7 @@ object FieldSerializerExamples extends Specification {
     Try { Extraction.extract[Dude](ser) } must beFailedTry
   }
 
-  "strictFieldSerialialization should not affect " in {
+  "rename functionality should not break strictFieldSerialialization" in {
     val customFormats = new DefaultFormats {
       override val strictFieldDeserialization: Boolean = true
     }


### PR DESCRIPTION
This pull request should address https://github.com/json4s/json4s/issues/432.

strictFieldDeserialization is now a property of Formats. Setting this property to true will allow strict field deserialization. 

Adding renameTo and renameFrom args to FieldSerializers does not break functionality.