### PR TITLE
fix class not found during deserializing in spark

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/ScalaSigReader.scala
+++ b/core/src/main/scala/org/json4s/reflect/ScalaSigReader.scala
@@ -187,7 +187,7 @@ object ScalaSigReader {
 
   val ModuleFieldName = "MODULE$"
   val OuterFieldName = "$outer"
-  val ClassLoaders = Vector(this.getClass.getClassLoader)
+  val ClassLoaders = Vector(this.getClass.getClassLoader, Thread.currentThread().getContextClassLoader)
 
   def companions(t: String, companion: Option[AnyRef] = None, classLoaders: Iterable[ClassLoader] = ClassLoaders) = {
     def path(tt: String) = if (tt.endsWith("$")) tt else (tt + "$")

--- a/core/src/main/scala/org/json4s/reflect/package.scala
+++ b/core/src/main/scala/org/json4s/reflect/package.scala
@@ -48,7 +48,7 @@ package object reflect {
 
   private[reflect] val ConstructorDefaultValuePattern = "$lessinit$greater$default$%d"
   private[reflect] val ModuleFieldName = "MODULE$"
-  private[reflect] val ClassLoaders = Vector(getClass.getClassLoader)
+  private[reflect] val ClassLoaders = Vector(getClass.getClassLoader, Thread.currentThread().getContextClassLoader)
   private[this] val paranamer = new CachingParanamer(new BytecodeReadingParanamer)
 
 


### PR DESCRIPTION
During deserializing in Spark, job fails on this line of `Extraction.scala` since the application classLoader not the same or the parents of  json4s classLoader.
```
val concreteClass = formats.typeHints.classFor(typeHint) getOrElse fail("Do not know how to deserialize '" + typeHint + "'")
```