### PR TITLE
3.6 backport: Fix class not found during deserializing in spark (#569)

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/ScalaSigReader.scala
+++ b/core/src/main/scala/org/json4s/reflect/ScalaSigReader.scala
@@ -187,7 +187,7 @@ object ScalaSigReader {
 
   val ModuleFieldName = "MODULE$"
   val OuterFieldName = "$outer"
-  val ClassLoaders = Vector(this.getClass.getClassLoader)
+  val ClassLoaders = Vector(this.getClass.getClassLoader, Thread.currentThread().getContextClassLoader)
 
   def companions(t: String, companion: Option[AnyRef] = None, classLoaders: Iterable[ClassLoader] = ClassLoaders) = {
     def path(tt: String) = if (tt.endsWith("$")) tt else (tt + "$")

--- a/core/src/main/scala/org/json4s/reflect/package.scala
+++ b/core/src/main/scala/org/json4s/reflect/package.scala
@@ -48,7 +48,7 @@ package object reflect {
 
   private[reflect] val ConstructorDefaultValuePattern = "$lessinit$greater$default$%d"
   private[reflect] val ModuleFieldName = "MODULE$"
-  private[reflect] val ClassLoaders = Vector(getClass.getClassLoader)
+  private[reflect] val ClassLoaders = Vector(getClass.getClassLoader, Thread.currentThread().getContextClassLoader)
   private[this] val paranamer = new CachingParanamer(new BytecodeReadingParanamer)
 
 


### PR DESCRIPTION
This pull request brings the backport of #569 to 3.6 series. The change is binary compatible.