### PR TITLE
3.6 backport: Executable: getMarkedAsPrimary should return true if isPrimaryCtor

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/Executable.scala
+++ b/core/src/main/scala/org/json4s/reflect/Executable.scala
@@ -62,11 +62,13 @@ class Executable private (val method: Method, val constructor: Constructor[_], i
   }
 
   def getMarkedAsPrimary(): Boolean = {
-    if (method == null) {
+    val markedByAnnotation = if (method == null) {
       constructor.isAnnotationPresent(classOf[PrimaryConstructor])
     } else {
       false
     }
+
+    markedByAnnotation || isPrimaryCtor
   }
 
   override def toString =

--- a/tests/src/test/scala/org/json4s/ExtractionBugs.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionBugs.scala
@@ -20,6 +20,7 @@ object WithPrimitiveAlias {
 case class WithPrimitiveAlias(foo: Seq[WithPrimitiveAlias.MyDouble])
 
 object ExtractionBugs {
+
   case class Response(data: List[Map[String, Int]])
 
   case class OptionOfInt(opt: Option[Int])
@@ -119,6 +120,12 @@ object ExtractionBugs {
   }
 
   case class CaseClassWithCompanion(value: String, other: String)
+
+  case class CompanionSample(s: String, i: Int)
+
+  object CompanionSample {
+    def apply(str: String, i1: Int, i2: Int): CompanionSample = CompanionSample(str, i1 + i2)
+  }
 
   /** Custom serializer for MapImplementation
    *  This is used to show that custom (strange) serialisations were once broken.
@@ -284,6 +291,12 @@ abstract class ExtractionBugs[T](mod: String) extends Specification with JsonMet
 
     "An implementation of Map should deserialize with a CustomSerializer" in {
       Extraction.extract[MapImplementation](MapImplementationSerializer.strangeSerialization) must_== new MapImplementation()
+    }
+
+    "Apply can't be mostComprehensive" in {
+      val obj = CompanionSample("hello", 1, 2)
+      val json = Extraction.decompose(obj)
+      json mustEqual JObject("s" -> JString("hello"), "i" -> JInt(3))
     }
   }
 }


### PR DESCRIPTION
This pull request brings the backport #572 which fixes #571 to 3.6 series.