### PR TITLE
3.6 backport: Support for java.math.BigDecimal/BigInteger deserialization (#574)

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -17,7 +17,7 @@
 package org.json4s
 
 import java.lang.{Integer => JavaInteger, Long => JavaLong, Short => JavaShort, Byte => JavaByte, Boolean => JavaBoolean, Double => JavaDouble, Float => JavaFloat}
-import java.math.{BigDecimal => JavaBigDecimal}
+import java.math.{BigDecimal => JavaBigDecimal, BigInteger => JavaBigInteger}
 import java.util.Date
 import java.sql.Timestamp
 import reflect._
@@ -585,7 +585,18 @@ object Extraction {
         case other: JValue => other
       }
 
-      val args = constructor.params.map(a => buildCtorArg(deserializedJson \ a.name, a))
+      val paramsWithOriginalTypes = constructor.params.zip(jconstructor.getParameterTypes())
+
+      val args = paramsWithOriginalTypes.collect {
+        case (param, clazz) =>
+          val rawArg = buildCtorArg(deserializedJson \ param.name, param)
+          (rawArg, clazz) match {
+            case (arg: BigDecimal, tt) if tt == classOf[JavaBigDecimal] => arg.bigDecimal
+            case (arg: BigInt, tt) if tt == classOf[JavaBigInteger] => arg.bigInteger
+            case (arg, _) => arg
+          }
+      }
+
       try {
         if (jconstructor.getDeclaringClass == classOf[java.lang.Object]) {
           deserializedJson match {


### PR DESCRIPTION
This pull request is a backport of #574 to 3.6 series.