### PR TITLE
allow building on JDK 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ scala:
   - 2.11.12
 matrix:
   include:
-  - scala: 2.12.7
+  - scala: 2.12.8
     jdk: oraclejdk8
   - scala: 2.13.0-M5
     jdk: oraclejdk8
     script:
     - sbt ++$TRAVIS_SCALA_VERSION test
   - dist: trusty
-    scala: 2.12.7
+    scala: 2.12.8
     jdk: openjdk11
     script:
     - ./sbt ++$TRAVIS_SCALA_VERSION test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/project/build.scala
+++ b/project/build.scala
@@ -60,8 +60,8 @@ object build {
 
   val json4sSettings = mavenCentralFrouFrou ++ Def.settings(
     organization := "org.json4s",
-    scalaVersion := "2.12.7",
-    crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.7", "2.13.0-M5"),
+    scalaVersion := "2.12.8",
+    crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0-M5"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:existentials", "-language:implicitConversions", "-language:higherKinds", "-language:postfixOps", "-Xfuture"),
     scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
       case Some((2, 10)) => "-optimize"
@@ -80,7 +80,15 @@ object build {
       }
     },
     version := "3.5.5-SNAPSHOT",
-    javacOptions ++= Seq("-target", "1.6", "-source", "1.6"),
+    javacOptions ++= {
+      val jdk = CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, scalaMajor)) if scalaMajor <= 11 =>
+          "1.6"
+        case _ =>
+          "1.8"
+      }
+      Seq("-target", jdk, "-source", jdk)
+    },
     javaVersionPrefix in javaVersionCheck := Some{
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, scalaMajor)) if scalaMajor <= 11 => "1.7"

--- a/publish_2.12.sh
+++ b/publish_2.12.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sbt ++2.12.7 javaVersionCheck publishSigned
+sbt ++2.12.8 javaVersionCheck publishSigned


### PR DESCRIPTION
JDK 12 drops support for `-source 1.6`, but we shouldn't be using
that when building on Scala 2.12 and above anyway

this turned up in the Scala-2.12-on-JDK-12 community build