### PR TITLE
Replaced from '⇒' to '=>'

### DIFF
--- a/ast/src/main/scala/org/json4s/JsonAST.scala
+++ b/ast/src/main/scala/org/json4s/JsonAST.scala
@@ -53,9 +53,9 @@ object JsonAST {
      * </pre>
      */
     def children: List[JValue] = this match {
-      case JObject(l) ⇒ l map (_._2)
-      case JArray(l) ⇒ l
-      case _ ⇒ Nil
+      case JObject(l) => l map (_._2)
+      case JArray(l) => l
+      case _ => Nil
     }
 
 
@@ -81,12 +81,12 @@ object JsonAST {
      */
     def ++(other: JValue) = {
       def append(value1: JValue, value2: JValue): JValue = (value1, value2) match {
-        case (JNothing, x) ⇒ x
-        case (x, JNothing) ⇒ x
-        case (JArray(xs), JArray(ys)) ⇒ JArray(xs ::: ys)
-        case (JArray(xs), v: JValue) ⇒ JArray(xs ::: List(v))
-        case (v: JValue, JArray(xs)) ⇒ JArray(v :: xs)
-        case (x, y) ⇒ JArray(x :: y :: Nil)
+        case (JNothing, x) => x
+        case (x, JNothing) => x
+        case (JArray(xs), JArray(ys)) => JArray(xs ::: ys)
+        case (JArray(xs), v: JValue) => JArray(xs ::: List(v))
+        case (v: JValue, JArray(xs)) => JArray(v :: xs)
+        case (x, y) => JArray(x :: y :: Nil)
       }
       append(this, other)
     }
@@ -96,8 +96,8 @@ object JsonAST {
      * When it has a value it will return [[scala.Some]]
      */
     def toOption: Option[JValue] = this match {
-      case JNothing | JNull ⇒ None
-      case json ⇒ Some(json)
+      case JNothing | JNull => None
+      case json => Some(json)
     }
 
     /**
@@ -150,11 +150,11 @@ object JsonAST {
 
   case class JObject(obj: List[JField]) extends JValue {
     type Values = Map[String, Any]
-    def values = obj.map { case (n, v) ⇒ (n, v.values) } toMap
+    def values = obj.map { case (n, v) => (n, v.values) } toMap
 
     override def equals(that: Any): Boolean = that match {
-      case o: JObject ⇒ obj.toSet == o.obj.toSet
-      case _ ⇒ false
+      case o: JObject => obj.toSet == o.obj.toSet
+      case _ => false
     }
 
     override def hashCode = obj.toSet[JField].hashCode
@@ -176,8 +176,8 @@ object JsonAST {
     def values = set
 
     override def equals(o: Any): Boolean = o match {
-      case o: JSet ⇒ o.values == values
-      case _ ⇒ false
+      case o: JSet => o.values == values
+      case _ => false
     }
 
     def intersect(o: JSet): JSet = JSet(o.values.intersect(values))

--- a/ast/src/main/scala/org/json4s/JsonDSL.scala
+++ b/ast/src/main/scala/org/json4s/JsonDSL.scala
@@ -25,7 +25,7 @@ import JsonAST._
  * JObject(JField("name", "joe") :: Nil) == JObject(JField("name", JString("joe")) :: Nil)
  * </pre>
  */
-trait BigDecimalMode { self: Implicits ⇒
+trait BigDecimalMode { self: Implicits =>
 
   implicit def double2jvalue(x: Double): JValue = JDecimal(x)
   implicit def float2jvalue(x: Float): JValue = JDecimal(x.toDouble)
@@ -33,7 +33,7 @@ trait BigDecimalMode { self: Implicits ⇒
 
 }
 object BigDecimalMode extends Implicits with BigDecimalMode
-trait DoubleMode { self: Implicits ⇒
+trait DoubleMode { self: Implicits =>
   implicit def double2jvalue(x: Double): JValue = JDouble(x)
   implicit def float2jvalue(x: Float): JValue = JDouble(x.toDouble)
   implicit def bigdecimal2jvalue(x: BigDecimal): JValue = JDouble(x.doubleValue)
@@ -68,14 +68,14 @@ object JsonDSL extends JsonDSL with DoubleMode {
 trait JsonDSL extends Implicits {
 
   implicit def seq2jvalue[A](s: Iterable[A])(implicit ev: A => JValue) =
-    JArray(s.toList.map { a ⇒ val v: JValue = a; v })
+    JArray(s.toList.map { a => val v: JValue = a; v })
 
   implicit def map2jvalue[A](m: Map[String, A])(implicit ev: A => JValue) =
-    JObject(m.toList.map { case (k, v) ⇒ JField(k, v) })
+    JObject(m.toList.map { case (k, v) => JField(k, v) })
 
   implicit def option2jvalue[A](opt: Option[A])(implicit ev: A => JValue): JValue = opt match {
-    case Some(x) ⇒ x
-    case None ⇒ JNothing
+    case Some(x) => x
+    case None => JNothing
   }
 
   implicit def symbol2jvalue(x: Symbol) = JString(x.name)

--- a/core/src/main/scala/org/json4s/ExtractableJsonAstNode.scala
+++ b/core/src/main/scala/org/json4s/ExtractableJsonAstNode.scala
@@ -55,7 +55,7 @@ class ExtractableJsonAstNode(jv: JValue) {
    * JNothing.extractOrElse(Person("joe")) == Person("joe")
    * </pre>
    */
-  def extractOrElse[A](default: ⇒ A)(implicit formats: Formats, mf: scala.reflect.Manifest[A]): A =
+  def extractOrElse[A](default: => A)(implicit formats: Formats, mf: scala.reflect.Manifest[A]): A =
     Extraction.extractOpt(jv)(formats, mf).getOrElse(default)
 
   /**
@@ -88,7 +88,7 @@ class ExtractableJsonAstNode(jv: JValue) {
    */
   def getAs[A](implicit reader: Reader[A]): Option[A] = try {
     Option(reader.read(jv))
-  } catch { case _: Throwable ⇒ None }
+  } catch { case _: Throwable => None }
 
   /**
    * Given that an implicit reader of type `A` is in scope
@@ -104,7 +104,7 @@ class ExtractableJsonAstNode(jv: JValue) {
    *   JObject(JField("name", JString("Joe")) :: Nil).getAsOrElse(Person("Tom"))
    * }}}
    */
-  def getAsOrElse[A](default: ⇒ A)(implicit reader: Reader[A]): A =
+  def getAsOrElse[A](default: => A)(implicit reader: Reader[A]): A =
     getAs(reader) getOrElse default
 }
 

--- a/core/src/main/scala/org/json4s/MonadicJValue.scala
+++ b/core/src/main/scala/org/json4s/MonadicJValue.scala
@@ -38,29 +38,29 @@ class MonadicJValue(jv: JValue) {
     case JArray(xs) => JArray(findDirectByName(xs, nameToFind))
     case _ =>
       findDirectByName(List(jv), nameToFind) match {
-        case Nil ⇒ JNothing
-        case x :: Nil ⇒ x
-        case x ⇒ JArray(x)
+        case Nil => JNothing
+        case x :: Nil => x
+        case x => JArray(x)
       }
   }
 
   private[this] def findDirectByName(xs: List[JValue], name: String): List[JValue] = xs.flatMap {
-    case JObject(l) ⇒ l.filter {
-      case (n, _) if n == name ⇒ true
-      case _ ⇒ false
+    case JObject(l) => l.filter {
+      case (n, _) if n == name => true
+      case _ => false
     } map (_._2)
-    case JArray(l) ⇒ findDirectByName(l, name)
-    case _ ⇒ Nil
+    case JArray(l) => findDirectByName(l, name)
+    case _ => Nil
   }
 
-  private[this] def findDirect(xs: List[JValue], p: JValue ⇒ Boolean): List[JValue] = xs.flatMap {
-    case JObject(l) ⇒ l.filter {
-      case (n@_, x) if p(x) ⇒ true
-      case _ ⇒ false
+  private[this] def findDirect(xs: List[JValue], p: JValue => Boolean): List[JValue] = xs.flatMap {
+    case JObject(l) => l.filter {
+      case (n@_, x) if p(x) => true
+      case _ => false
     } map (_._2)
-    case JArray(l) ⇒ findDirect(l, p)
-    case x if p(x) ⇒ x :: Nil
-    case _ ⇒ Nil
+    case JArray(l) => findDirect(l, p)
+    case x if p(x) => x :: Nil
+    case _ => Nil
   }
 
   /**
@@ -72,16 +72,16 @@ class MonadicJValue(jv: JValue) {
    */
   def \\(nameToFind: String): JValue = {
     def find(json: JValue): List[JField] = json match {
-      case JObject(l) ⇒ l.foldLeft(List[JField]()) {
-        case (a, (name, value)) ⇒
+      case JObject(l) => l.foldLeft(List[JField]()) {
+        case (a, (name, value)) =>
           if (name == nameToFind) a ::: List((name, value)) ::: find(value) else a ::: find(value)
       }
-      case JArray(l) ⇒ l.foldLeft(List[JField]())((a, json) ⇒ a ::: find(json))
-      case _ ⇒ Nil
+      case JArray(l) => l.foldLeft(List[JField]())((a, json) => a ::: find(json))
+      case _ => Nil
     }
     find(jv) match {
-      case (_, x) :: Nil ⇒ x
-      case xs ⇒ JObject(xs)
+      case (_, x) :: Nil => x
+      case xs => JObject(xs)
     }
   }
 
@@ -107,21 +107,21 @@ class MonadicJValue(jv: JValue) {
     (jv filter typePredicate(clazz) _).asInstanceOf[List[A]] map { _.values }
 
   private def typePredicate[A <: JValue](clazz: Class[A])(json: JValue) = json match {
-    case x if x.getClass == clazz ⇒ true
-    case _ ⇒ false
+    case x if x.getClass == clazz => true
+    case _ => false
   }
 
   /**
    * Return a combined value by folding over JSON by applying a function <code>f</code>
    * for each element. The initial value is <code>z</code>.
    */
-  def fold[A](z: A)(f: (A, JValue) ⇒ A): A = {
+  def fold[A](z: A)(f: (A, JValue) => A): A = {
     def rec(acc: A, v: JValue) = {
       val newAcc = f(acc, v)
       v match {
-        case JObject(l) ⇒ l.foldLeft(newAcc) { case (a, (name@_, value)) ⇒ value.fold(a)(f) }
-        case JArray(l) ⇒ l.foldLeft(newAcc)((a, e) ⇒ e.fold(a)(f))
-        case _ ⇒ newAcc
+        case JObject(l) => l.foldLeft(newAcc) { case (a, (name@_, value)) => value.fold(a)(f) }
+        case JArray(l) => l.foldLeft(newAcc)((a, e) => e.fold(a)(f))
+        case _ => newAcc
       }
     }
     rec(z, jv)
@@ -131,14 +131,14 @@ class MonadicJValue(jv: JValue) {
    * Return a combined value by folding over JSON by applying a function <code>f</code>
    * for each field. The initial value is <code>z</code>.
    */
-  def foldField[A](z: A)(f: (A, JField) ⇒ A): A = {
+  def foldField[A](z: A)(f: (A, JField) => A): A = {
     def rec(acc: A, v: JValue) = {
       v match {
-        case JObject(l) ⇒ l.foldLeft(acc) {
-          case (a, field @ (name@_, value)) ⇒ value.foldField(f(a, field))(f)
+        case JObject(l) => l.foldLeft(acc) {
+          case (a, field @ (name@_, value)) => value.foldField(f(a, field))(f)
         }
-        case JArray(l) ⇒ l.foldLeft(acc)((a, e) ⇒ e.foldField(a)(f))
-        case _ ⇒ acc
+        case JArray(l) => l.foldLeft(acc)((a, e) => e.foldField(a)(f))
+        case _ => acc
       }
     }
     rec(z, jv)
@@ -155,11 +155,11 @@ class MonadicJValue(jv: JValue) {
    * }
    * </pre>
    */
-  def map(f: JValue ⇒ JValue): JValue = {
+  def map(f: JValue => JValue): JValue = {
     def rec(v: JValue): JValue = v match {
-      case JObject(l) ⇒ f(JObject(l.map { case (n, va) ⇒ (n, rec(va)) }))
-      case JArray(l) ⇒ f(JArray(l.map(rec)))
-      case x ⇒ f(x)
+      case JObject(l) => f(JObject(l.map { case (n, va) => (n, rec(va)) }))
+      case JArray(l) => f(JArray(l.map(rec)))
+      case x => f(x)
     }
     rec(jv)
   }
@@ -175,11 +175,11 @@ class MonadicJValue(jv: JValue) {
    * }
    * </pre>
    */
-  def mapField(f: JField ⇒ JField): JValue = {
+  def mapField(f: JField => JField): JValue = {
     def rec(v: JValue): JValue = v match {
-      case JObject(l) ⇒ JObject(l.map { case (n, va) ⇒ f(n -> rec(va)) })
-      case JArray(l) ⇒ JArray(l.map(rec))
-      case x ⇒ x
+      case JObject(l) => JObject(l.map { case (n, va) => f(n -> rec(va)) })
+      case JArray(l) => JArray(l.map(rec))
+      case x => x
     }
     rec(jv)
   }
@@ -194,7 +194,7 @@ class MonadicJValue(jv: JValue) {
    * }
    * </pre>
    */
-  def transformField(f: PartialFunction[JField, JField]): JValue = mapField { x ⇒
+  def transformField(f: PartialFunction[JField, JField]): JValue = mapField { x =>
     if (f.isDefinedAt(x)) f(x) else x
   }
 
@@ -206,7 +206,7 @@ class MonadicJValue(jv: JValue) {
    * JArray(JInt(1) :: JInt(2) :: Nil) transform { case JInt(x) => JInt(x+1) }
    * </pre>
    */
-  def transform(f: PartialFunction[JValue, JValue]): JValue = map { x ⇒
+  def transform(f: PartialFunction[JValue, JValue]): JValue = map { x =>
     if (f.isDefinedAt(x)) f(x) else x
   }
 
@@ -253,8 +253,8 @@ class MonadicJValue(jv: JValue) {
         // "foo" or "foo"."bar"
         case (x :: xs, JObject(fields)) => JObject(
           fields.map {
-            case JField(`x`, value) ⇒ JField(x, if(xs == Nil) replacement else rep(xs, value))
-            case field ⇒ field
+            case JField(`x`, value) => JField(x, if(xs == Nil) replacement else rep(xs, value))
+            case field => field
           }
         )
 
@@ -274,12 +274,12 @@ class MonadicJValue(jv: JValue) {
    * JObject(("age", JInt(2))) findField { case (n, v) => n == "age" }
    * </pre>
    */
-  def findField(p: JField ⇒ Boolean): Option[JField] = {
+  def findField(p: JField => Boolean): Option[JField] = {
     def find(json: JValue): Option[JField] = json match {
-      case JObject(fs) if fs exists p ⇒ fs find p
-      case JObject(fs) ⇒ fs.flatMap { case (_, v) ⇒ find(v) }.headOption
-      case JArray(l) ⇒ l.flatMap(find _).headOption
-      case _ ⇒ None
+      case JObject(fs) if fs exists p => fs find p
+      case JObject(fs) => fs.flatMap { case (_, v) => find(v) }.headOption
+      case JArray(l) => l.flatMap(find _).headOption
+      case _ => None
     }
     find(jv)
   }
@@ -291,13 +291,13 @@ class MonadicJValue(jv: JValue) {
    * JArray(JInt(1) :: JInt(2) :: Nil) find { _ == JInt(2) } == Some(JInt(2))
    * </pre>
    */
-  def find(p: JValue ⇒ Boolean): Option[JValue] = {
+  def find(p: JValue => Boolean): Option[JValue] = {
     def find(json: JValue): Option[JValue] = {
       if (p(json)) return Some(json)
       json match {
-        case JObject(fs) ⇒ fs.flatMap { case (_, v) ⇒ find(v) }.headOption
-        case JArray(l) ⇒ l.flatMap(find _).headOption
-        case _ ⇒ None
+        case JObject(fs) => fs.flatMap { case (_, v) => find(v) }.headOption
+        case JArray(l) => l.flatMap(find _).headOption
+        case _ => None
       }
     }
     find(jv)
@@ -313,8 +313,8 @@ class MonadicJValue(jv: JValue) {
    * }
    * </pre>
    */
-  def filterField(p: JField ⇒ Boolean): List[JField] =
-    foldField(List[JField]())((acc, e) ⇒ if (p(e)) e :: acc else acc).reverse
+  def filterField(p: JField => Boolean): List[JField] =
+    foldField(List[JField]())((acc, e) => if (p(e)) e :: acc else acc).reverse
 
   /**
    * Return a List of all values which matches the given predicate.
@@ -323,8 +323,8 @@ class MonadicJValue(jv: JValue) {
    * JArray(JInt(1) :: JInt(2) :: Nil) filter { case JInt(x) => x > 1; case _ => false }
    * </pre>
    */
-  def filter(p: JValue ⇒ Boolean): List[JValue] =
-    fold(List[JValue]())((acc, e) ⇒ if (p(e)) e :: acc else acc).reverse
+  def filter(p: JValue => Boolean): List[JValue] =
+    fold(List[JValue]())((acc, e) => if (p(e)) e :: acc else acc).reverse
 
   def withFilter(p: JValue => Boolean) = new JValueWithFilter(jv, p)
   class JValueWithFilter(self: JValue, p: JValue => Boolean) {
@@ -348,7 +348,7 @@ class MonadicJValue(jv: JValue) {
    * }
    * </pre>
    */
-  def removeField(p: JField ⇒ Boolean): JValue = jv transform {
+  def removeField(p: JField => Boolean): JValue = jv transform {
     case JObject(l) => JObject(l.filterNot(p))
   }
 
@@ -359,10 +359,10 @@ class MonadicJValue(jv: JValue) {
    * JArray(JInt(1) :: JInt(2) :: JNull :: Nil) remove { _ == JNull }
    * </pre>
    */
-  def remove(p: JValue ⇒ Boolean): JValue = {
+  def remove(p: JValue => Boolean): JValue = {
     if(p(jv)) JNothing
     else jv transform {
-      case JObject(l) => JObject(l.filterNot(f ⇒ p(f._2)))
+      case JObject(l) => JObject(l.filterNot(f => p(f._2)))
       case JArray(l) => JArray(l.filterNot(p))
     }
   }
@@ -377,8 +377,8 @@ class MonadicJValue(jv: JValue) {
   }
   private[this] def pascalize(word: String): String = {
     val lst = word.split("_").toList
-    (lst.headOption.map(s ⇒ s.substring(0, 1).toUpperCase(ENGLISH) + s.substring(1)).get ::
-      lst.tail.map(s ⇒ s.substring(0, 1).toUpperCase + s.substring(1))).mkString("")
+    (lst.headOption.map(s => s.substring(0, 1).toUpperCase(ENGLISH) + s.substring(1)).get ::
+      lst.tail.map(s => s.substring(0, 1).toUpperCase + s.substring(1))).mkString("")
   }
   private[this] def underscoreCamelCasesOnly(word: String): String = {
     val firstPattern = "([A-Z]+)([A-Z][a-z])".r
@@ -423,7 +423,7 @@ class MonadicJValue(jv: JValue) {
 
   private[this] def rewriteJsonAST(keyCaseTransform: String => String): JValue =
     transformField {
-      case JField(nm, x) if !nm.startsWith("_") ⇒ JField(keyCaseTransform(nm), x)
+      case JField(nm, x) if !nm.startsWith("_") => JField(keyCaseTransform(nm), x)
     }
 
   /**

--- a/examples/src/main/scala/org/json4s/examples/Swagger.scala
+++ b/examples/src/main/scala/org/json4s/examples/Swagger.scala
@@ -99,7 +99,7 @@ object Api {
       def parse(s: String) = try {
         Option(Iso8601Date.parseDateTime(s).toDate)
       } catch {
-        case scala.util.control.NonFatal(_) ⇒ None
+        case scala.util.control.NonFatal(_) => None
       }
       def timezone = TimeZone.getTimeZone("UTC")
     }
@@ -122,7 +122,7 @@ object SwaggerSerializers {
   class HttpMethodSerializer extends CustomSerializer[HttpMethod](formats => ({
     case JString(meth) => HttpMethod(meth)
   }, {
-    case x: HttpMethod ⇒ JString(x.toString)
+    case x: HttpMethod => JString(x.toString)
   }))
 
   private[this] val simpleTypeList: List[String] = List("string", "number", "int", "boolean", "object", "Array", "null", "any")
@@ -220,11 +220,11 @@ object SwaggerSerializers {
         case _ => AllowableValues.AnyValue
       }
   },{
-    case AllowableValues.AnyValue ⇒ JNothing
-    case AllowableValues.AllowableValuesList(values)  ⇒
+    case AllowableValues.AnyValue => JNothing
+    case AllowableValues.AllowableValuesList(values)  =>
       implicit val fmts = formats
       ("valueType" -> "LIST") ~ ("values" -> Extraction.decompose(values))
-    case AllowableValues.AllowableRangeValues(range)  ⇒ ("valueType" -> "RANGE") ~ ("min" -> range.start) ~ ("max" -> range.end)
+    case AllowableValues.AllowableRangeValues(range)  => ("valueType" -> "RANGE") ~ ("min" -> range.start) ~ ("max" -> range.end)
   }))
 }
 

--- a/ext/src/main/scala/org/json4s/ext/JavaEnumSerializer.scala
+++ b/ext/src/main/scala/org/json4s/ext/JavaEnumSerializer.scala
@@ -21,8 +21,8 @@ import java.lang.Enum
 
 class JavaEnumNameSerializer[E <: Enum[E]](
   implicit ct: Manifest[E]
-) extends CustomSerializer[E](_ ⇒ ({
-  case JString(name) ⇒ Enum.valueOf(ct.runtimeClass.asInstanceOf[Class[E]], name)
+) extends CustomSerializer[E](_ => ({
+  case JString(name) => Enum.valueOf(ct.runtimeClass.asInstanceOf[Class[E]], name)
 }, {
-  case dt: E ⇒ JString(dt.name())
+  case dt: E => JString(dt.name())
 }))


### PR DESCRIPTION
because The unicode arrow `⇒` is deprecated.