### PR TITLE
replaced from Symbol literal to Symbol class

### DIFF
--- a/tests/src/test/scala/org/json4s/Examples.scala
+++ b/tests/src/test/scala/org/json4s/Examples.scala
@@ -120,7 +120,7 @@ object Examples {
 
   val nulls = JObject("f1" -> null) ~ ("f2" -> List(null, "s"))
   val quoted = """["foo \" \n \t \r bar"]"""
-  val symbols = ("f1" -> 'foo) ~ ("f2" -> 'bar)
+  val symbols = ("f1" -> Symbol("foo")) ~ ("f2" -> Symbol("bar"))
 }
 
 abstract class Examples[T](mod: String) extends Specification with JsonMethods[T] {

--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -109,7 +109,7 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
 
     "Primitive extraction example" in {
       val json = parse(primitives)
-      json.extract[Primitives] must_== Primitives(124, 123L, 126.5, 127.5.floatValue, "128", 'symb, 125, 129.byteValue, true)
+      json.extract[Primitives] must_== Primitives(124, 123L, 126.5, 127.5.floatValue, "128", Symbol("symb"), 125, 129.byteValue, true)
     }
 
     "Null extraction example" in {

--- a/tests/src/test/scala/org/json4s/native/MapSerializationExamples.scala
+++ b/tests/src/test/scala/org/json4s/native/MapSerializationExamples.scala
@@ -11,7 +11,7 @@ class MapSerializationExamples extends Specification {
   implicit val formats = native.Serialization.formats(NoTypeHints)
 
   "Map with Symbol key" in {
-    val pw = Map[Symbol, String]('a -> "hello", 'b -> "world")
+    val pw = Map[Symbol, String](Symbol("a") -> "hello", Symbol("b") -> "world")
     val ser = swrite(pw)
     ser must_== """{"a":"hello","b":"world"}"""
     read[Map[Symbol, String]](ser) must_== pw

--- a/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
+++ b/tests/src/test/scala/org/json4s/native/SerializationExamples.scala
@@ -62,7 +62,7 @@ object SerializationExamples extends Specification {
   }
 
   "Primitive serialization example" in {
-    val primitives = Primitives(124, 123L, 126.5, 127.5.floatValue, "128", 's, 125, 129.byteValue, true)
+    val primitives = Primitives(124, 123L, 126.5, 127.5.floatValue, "128", Symbol("s"), 125, 129.byteValue, true)
     val ser = swrite(primitives)
     read[Primitives](ser) must_== primitives
   }


### PR DESCRIPTION
Symbol literal is deprecated at Scala 2.13