### PR TITLE
Added targetType parameter to allowNull Formats' method to selectively permit null values for certain types

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -668,8 +668,8 @@ object Extraction {
 
     def result: Any =
       json match {
-        case JNull if formats.allowNull => null
-        case JNull if !formats.allowNull =>
+        case JNull if formats.allowNull(descr.erasure.erasure) => null
+        case JNull if !formats.allowNull(descr.erasure.erasure) =>
           fail("Did not find value which can be converted into " + descr.fullName)
         case JObject(TypeHint(t, fs)) => mkWithTypeHint(t, fs, descr.erasure)
         case _ => instantiate
@@ -773,8 +773,8 @@ object Extraction {
       case j: JValue if (targetType == classOf[JValue]) => j
       case j: JObject if (targetType == classOf[JObject]) => j
       case j: JArray if (targetType == classOf[JArray]) => j
-      case JNull if formats.allowNull => null
-      case JNull if !formats.allowNull =>
+      case JNull if formats.allowNull(targetType) => null
+      case JNull if !formats.allowNull(targetType) =>
         fail("Did not find value which can be converted into " + targetType.getName)
       case JNothing =>
         default map (_.apply()) getOrElse fail("Did not find value which can be converted into " + targetType.getName)

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -79,7 +79,7 @@ trait Formats extends Serializable { self: Formats =>
   def wantsBigDecimal: Boolean = false
   def primitives: Set[Type] = Set(classOf[JValue], classOf[JObject], classOf[JArray])
   def companions: List[(Class[_], AnyRef)] = Nil
-  def allowNull: Boolean = true
+  def allowNull(targetType: Class[_]): Boolean = true
   def strictOptionParsing: Boolean = false
   def strictArrayExtraction: Boolean = false
   def alwaysEscapeUnicode: Boolean = false
@@ -109,7 +109,7 @@ trait Formats extends Serializable { self: Formats =>
                     wWantsBigDecimal: Boolean = self.wantsBigDecimal,
                     withPrimitives: Set[Type] = self.primitives,
                     wCompanions: List[(Class[_], AnyRef)] = self.companions,
-                    wAllowNull: Boolean = self.allowNull,
+                    wAllowNull: Class[_] => Boolean = self.allowNull,
                     wStrictOptionParsing: Boolean = self.strictOptionParsing,
                     wStrictArrayExtraction: Boolean = self.strictArrayExtraction,
                     wAlwaysEscapeUnicode: Boolean = self.alwaysEscapeUnicode,
@@ -127,7 +127,7 @@ trait Formats extends Serializable { self: Formats =>
       override def wantsBigDecimal: Boolean = wWantsBigDecimal
       override def primitives: Set[Type] = withPrimitives
       override def companions: List[(Class[_], AnyRef)] = wCompanions
-      override def allowNull: Boolean = wAllowNull
+      override def allowNull(targetType: Class[_]): Boolean = wAllowNull(targetType)
       override def strictOptionParsing: Boolean = wStrictOptionParsing
       override def strictArrayExtraction: Boolean = wStrictArrayExtraction
       override def alwaysEscapeUnicode: Boolean = wAlwaysEscapeUnicode
@@ -163,7 +163,7 @@ trait Formats extends Serializable { self: Formats =>
 
   def nonStrict: Formats = copy(wStrictOptionParsing = false, wStrictArrayExtraction = false)
   
-  def disallowNull: Formats = copy(wAllowNull = false)
+  def disallowNull: Formats = copy(wAllowNull = _ => false)
 
   def withStrictFieldDeserialization: Formats = copy(wStrictFieldDeserialization = true)
 
@@ -411,7 +411,7 @@ trait DefaultFormats extends Formats {
   override val companions: List[(Class[_], AnyRef)] = Nil
   override val strictOptionParsing: Boolean = false
   override val emptyValueStrategy: EmptyValueStrategy = EmptyValueStrategy.default
-  override val allowNull: Boolean = true
+  override def allowNull(targetType: Class[_]): Boolean = super.allowNull(targetType)
   override def strictFieldDeserialization: Boolean = false
 
 

--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -30,7 +30,7 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
   implicit lazy val formats = DefaultFormats
 
   val notNullFormats = new DefaultFormats {
-    override val allowNull = false
+    override def allowNull(targetType: Class[_]) = false
   }
 
   val strictFormats = formats.strict

--- a/tests/src/test/scala/org/json4s/FormatsBugs.scala
+++ b/tests/src/test/scala/org/json4s/FormatsBugs.scala
@@ -7,10 +7,10 @@ class FormatsBugs extends Specification {
   "Formats" should {
     "retain 'allowNull' setting over updates" in {
       val f = new DefaultFormats {
-        override val allowNull: Boolean = false
+        override def allowNull(targetType: Class[_]) = false
       }
       val fModified = f.withBigDecimal
-      fModified.allowNull must beFalse
+      fModified.allowNull(classOf[String]) must beFalse
     }
   }
 


### PR DESCRIPTION
We need to be able to allow null values based on the type of the attribute we wish to parse.

Consider the following example:

```scala
Action(
  requiredField: String, // This should not allow null
  clearableField: Clearable[String] // This should allow and treat differently: (JString, JNull, JNothing)
)
```

* `requiredField` must always be set and cannot be `JNull` (it must fail to parse if `null`).
* To update the value of `clearableField`, we send a new value using `JString`
* To clear the existing value associated with `clearableField`, we send `JNull`
* To only update `requiredField`, we simply not send `clearableField` which is `JNothing`.

To achieve this, we can simply modify the `allowNull` method in `Formats` as follows:
```scala
def allowNull: Boolean = true
```
Becomes:
```scala
def allowNull(targetType: Class[_]): Boolean = true
```

This allows us to conveniently define `allowNull` in our own `Formats` as:
```scala
override def allowNull(targetType: Class[_]): Boolean =
  targetType == classOf[Clearable[_]]
```