### PR TITLE
name based extractor to avoid instantiation

### DIFF
--- a/ast/src/main/scala/org/json4s/JsonAST.scala
+++ b/ast/src/main/scala/org/json4s/JsonAST.scala
@@ -189,7 +189,11 @@ object JsonAST {
   type JField = (String, JValue)
   object JField {
     def apply(name: String, value: JValue) = (name, value)
-    def unapply(f: JField): Option[(String, JValue)] = Some(f)
+
+    final class OptionStringJValue(val get: JField) extends AnyVal {
+      def isEmpty: Boolean = false
+    }
+    def unapply(f: JField): OptionStringJValue = new OptionStringJValue(f)
   }
 }
 


### PR DESCRIPTION
more info: https://github.com/scala/scala/pull/2848

Similar to https://github.com/json4s/json4s/pull/419 that was rejected because of compatibility with scala 2.10
Now that we don't use scala 2.10 anymore, this can be relevant again.