### PR TITLE
Document the ~~ variant of ~

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ scala> compact(render(json))
 res2: String = {"name":"joe","age":35}
 ```
 
+* ~~ operator works the same as ~ and is useful in situations where ~ is shadowed, eg. when using Spray or akka-http.
+
+```scala
+scala> val json = ("name" -> "joe") ~~ ("age" -> 35)
+
+scala> compact(render(json))
+res2: String = {"name":"joe","age":35}
+```
+
 * Any value can be optional. The field and value are completely removed when it doesn't have a value.
 
 ```scala


### PR DESCRIPTION
It just took me several hours of troubleshooting to find out why I got `value ~ is not a member of (String, X)` when writing an `akka-http`-endpoint. 

I eventually found https://github.com/json4s/json4s/issues/121 (which I believe should be closed?) but it would be great if this and any other overloaded operators were obviously documented to make them a bit easier to find