### PR TITLE
Issue #661: Downvotes on args with defaults will cause the least correct ctor to be used.

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/descriptors.scala
+++ b/core/src/main/scala/org/json4s/reflect/descriptors.scala
@@ -56,6 +56,7 @@ case class ClassDescriptor(
       args.foldLeft(0)((s, arg) =>
         if (names.contains(arg.name)) s+1
         else if (arg.isOptional) s
+        else if (arg.hasDefault) s
         else -100
       )
 

--- a/tests/src/test/scala/org/json4s/SerializationSpec.scala
+++ b/tests/src/test/scala/org/json4s/SerializationSpec.scala
@@ -163,3 +163,4 @@ case class BadSpec(item2: Int, item3: Int, isVisited: Boolean = false)
 case object BadSpec {
   def apply(item1: Int, item2: Int, item3: Int): BadSpec = BadSpec(item2, item3)
 }
+

--- a/tests/src/test/scala/org/json4s/SerializationSpec.scala
+++ b/tests/src/test/scala/org/json4s/SerializationSpec.scala
@@ -151,8 +151,15 @@ abstract class SerializationSpec(serialization: Serialization, baseFormats: Form
         val actual = Extraction.extract[AnotherModel](jackson.parseJson(json))
         actual must_== expected
       }
+
+      "#661 Matching algorithm picks least correct ctor" in {
+        serialization.read[BadSpec](s"""{"item2": 789, "item3": 123}""") must_== BadSpec(789, 123)
+      }
     }
-
   }
+}
 
+case class BadSpec(item2: Int, item3: Int, isVisited: Boolean = false)
+case object BadSpec {
+  def apply(item1: Int, item2: Int, item3: Int): BadSpec = BadSpec(item2, item3)
 }


### PR DESCRIPTION
This is a proposed solution to the problem.  I believe that the voting algorithm should treat non-optional args that have defaults with neutrality.