### PR TITLE
traverse fields only once by testing existence with find

### DIFF
--- a/core/src/main/scala/org/json4s/MonadicJValue.scala
+++ b/core/src/main/scala/org/json4s/MonadicJValue.scala
@@ -279,8 +279,7 @@ class MonadicJValue(jv: JValue) {
    */
   def findField(p: JField => Boolean): Option[JField] = {
     def find(json: JValue): Option[JField] = json match {
-      case JObject(fs) if fs exists p => fs find p
-      case JObject(fs) => fs.flatMap { case (_, v) => find(v) }.headOption
+      case JObject(fs) => fs.find(p).orElse(fs.flatMap { case (_, v) => find(v) }.headOption)
       case JArray(l) => l.flatMap(find _).headOption
       case _ => None
     }


### PR DESCRIPTION
This PR proposes a performance optimization for `findField` in `MonadicJValue`. 

With this implementation we only traverse the fields once and remove the call to `exists`.