### PR TITLE
Allow treating null values as absent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,14 @@ val formats: Formats = new DefaultFormats { override val considerCompanionConstr
 
 When this option is disabled, only primary and secondary constructors will be evaluated for use during extraction.
 
+Handling `null`
+-------------
+
+`null` values of `Option`s are always extracted as `None`. For other types you can control the behaviour by setting the `nullExtractionStrategy` of the `Formats` used during extraction. There are three options:
+* `Keep`: Leaves null values as they are.
+* `Disallow`: Fails extraction when a `null` value is encountered.
+* `TreatAsAbsent`: Treats `null` values as if they were not present at all.
+
 Serialization
 =============
 

--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -22,6 +22,7 @@ import java.sql.Timestamp
 import java.util.Date
 
 import org.json4s
+import org.json4s.prefs.ExtractionNullStrategy
 import org.json4s.reflect._
 
 import scala.collection.JavaConverters._
@@ -446,9 +447,15 @@ object Extraction {
     private[this] val typeArg = tpe.typeArgs.head
     private[this] def mkCollection(constructor: Array[_] => Any) = {
       val array: Array[_] = json match {
-        case JArray(arr)      => arr.map(extractDetectingNonTerminal(_, typeArg)).toArray
-        case JNothing | JNull if !formats.strictArrayExtraction => Array[AnyRef]()
-        case x                => fail("Expected collection but got " + x + " for root " + json + " and mapping " + tpe)
+        case JArray(arr) =>
+          arr.flatMap {
+            case JNull if formats.extractionNullStrategy == ExtractionNullStrategy.TreatAsAbsent => None
+            case el => Some(extractDetectingNonTerminal(el, typeArg))
+          }.toArray
+        case JNothing | JNull if !formats.strictArrayExtraction =>
+          Array[AnyRef]()
+        case x =>
+          fail("Expected collection but got " + x + " for root " + json + " and mapping " + tpe)
       }
 
       constructor(array)
@@ -571,35 +578,49 @@ object Extraction {
     }
 
     private[this] def buildCtorArg(json: JValue, descr: ConstructorParamDescriptor) = {
-      val default = descr.defaultValue
-      def defv(v: Any) = default.map(_()).getOrElse(v)
-
-      if (descr.isOptional && json == JNothing) {
-        if (formats.strictOptionParsing) {
-          fail(s"No value set for Option property: ${descr.name}")
+      try {
+        if(descr.isOptional) {
+          buildOptionalCtorArg(json, descr)
+        } else {
+          buildMandatoryCtorArg(json, descr)
         }
-        defv(None)
+      } catch {
+        case e @ MappingException(msg, _) =>
+          fail("No usable value for " + descr.name + "\n" + msg, e)
       }
-      else {
+    }
+
+    private[this] def buildOptionalCtorArg(json: JValue, descr: ConstructorParamDescriptor) = {
+      lazy val default = descr.defaultValue.map(_.apply()).getOrElse(None)
+      if(json == JNothing) {
+        if(formats.strictOptionParsing) fail(s"No value set for Option property: ${descr.name}") else default
+      } else {
         try {
-          val x = if (json == JNothing && default.isDefined) default.get() else extract(json, descr.argType)
-          if (descr.isOptional) { if (x == null) defv(None) else x }
-          else if (x == null) {
-            if(default.isEmpty && descr.argType <:< ScalaType(manifest[AnyVal])) {
-              throw new MappingException("Null invalid value for a sub-type of AnyVal")
-            } else {
-              defv(x)
-            }
-          }
-          else x
+          Option(extract(json, descr.argType)).getOrElse(default)
         } catch {
-          case e @ MappingException(msg, _) =>
-            if (descr.isOptional && !formats.strictOptionParsing) {
-              defv(None)
-            } else fail("No usable value for " + descr.name + "\n" + msg, e)
+          case _: MappingException if !formats.strictOptionParsing => default
         }
       }
     }
+
+    private[this] def buildMandatoryCtorArg(json: JValue, descr: ConstructorParamDescriptor) = {
+      lazy val default: Option[Any] = descr.defaultValue.map(_.apply())
+      if(json == JNothing) {
+        default.getOrElse(extract(json, descr.argType))
+      } else if(json == JNull && formats.extractionNullStrategy == ExtractionNullStrategy.TreatAsAbsent) {
+        default.getOrElse(throw new MappingException("Expected value but got null"))
+      } else {
+        Option(extract(json, descr.argType)) match {
+          case Some(value) =>
+            value
+          case None if descr.defaultValue.isEmpty && descr.argType <:< ScalaType(manifest[AnyVal]) =>
+            throw new MappingException("Null invalid value for a sub-type of AnyVal")
+          case None =>
+            default.orNull
+        }
+      }
+    }
+
 
     private[this] def instantiate = {
       val jconstructor = constructor.constructor
@@ -676,8 +697,8 @@ object Extraction {
       json match {
         case JNull if formats.strictOptionParsing && descr.properties.exists(_.returnType.isOption) =>
           fail(s"No value set for Option property: ${descr.properties.filter(_.returnType.isOption).map(_.name).mkString(", ")}")
-        case JNull if formats.allowNull => null
-        case JNull if !formats.allowNull =>
+        case JNull if formats.extractionNullStrategy == ExtractionNullStrategy.Keep => null
+        case JNull =>
           fail("Did not find value which can be converted into " + descr.fullName)
         case JObject(TypeHint(t, fs)) => mkWithTypeHint(t, fs, descr.erasure)
         case _ => instantiate
@@ -786,8 +807,8 @@ object Extraction {
       case j: JValue if targetType == classOf[JValue] => j
       case j: JObject if targetType == classOf[JObject] => j
       case j: JArray if targetType == classOf[JArray] => j
-      case JNull if formats.allowNull => null
-      case JNull if !formats.allowNull =>
+      case JNull if formats.extractionNullStrategy == ExtractionNullStrategy.Keep => null
+      case JNull =>
         fail("Did not find value which can be converted into " + targetType.getName)
       case JNothing =>
         default map (_.apply()) getOrElse fail("Did not find value which can be converted into " + targetType.getName)

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -23,6 +23,7 @@ import reflect.ScalaType
 import java.lang.reflect.Type
 
 import org.json4s.prefs.EmptyValueStrategy
+import org.json4s.prefs.ExtractionNullStrategy
 import org.json4s.reflect.Reflector
 
 import scala.annotation.implicitNotFound
@@ -98,7 +99,7 @@ trait Formats extends Serializable { self: Formats =>
   def wantsBigDecimal: Boolean = false
   def primitives: Set[Type] = Set(classOf[JValue], classOf[JObject], classOf[JArray])
   def companions: List[(Class[_], AnyRef)] = Nil
-  def allowNull: Boolean = true
+  def extractionNullStrategy: ExtractionNullStrategy = ExtractionNullStrategy.Keep
   def strictOptionParsing: Boolean = false
   def strictArrayExtraction: Boolean = false
   def alwaysEscapeUnicode: Boolean = false
@@ -131,7 +132,7 @@ trait Formats extends Serializable { self: Formats =>
                     wWantsBigDecimal: Boolean = self.wantsBigDecimal,
                     withPrimitives: Set[Type] = self.primitives,
                     wCompanions: List[(Class[_], AnyRef)] = self.companions,
-                    wAllowNull: Boolean = self.allowNull,
+                    wExtractionNullStrategy: ExtractionNullStrategy = self.extractionNullStrategy,
                     wStrictOptionParsing: Boolean = self.strictOptionParsing,
                     wStrictArrayExtraction: Boolean = self.strictArrayExtraction,
                     wAlwaysEscapeUnicode: Boolean = self.alwaysEscapeUnicode,
@@ -150,7 +151,7 @@ trait Formats extends Serializable { self: Formats =>
       override def wantsBigDecimal: Boolean = wWantsBigDecimal
       override def primitives: Set[Type] = withPrimitives
       override def companions: List[(Class[_], AnyRef)] = wCompanions
-      override def allowNull: Boolean = wAllowNull
+      override def extractionNullStrategy: ExtractionNullStrategy = wExtractionNullStrategy
       override def strictOptionParsing: Boolean = wStrictOptionParsing
       override def strictArrayExtraction: Boolean = wStrictArrayExtraction
       override def alwaysEscapeUnicode: Boolean = wAlwaysEscapeUnicode
@@ -194,7 +195,10 @@ trait Formats extends Serializable { self: Formats =>
 
   def nonStrict: Formats = copy(wStrictOptionParsing = false, wStrictArrayExtraction = false)
 
-  def disallowNull: Formats = copy(wAllowNull = false)
+  @deprecated(message = "Use withNullExtractionStrategy instead", since = "3.7.0")
+  def disallowNull: Formats = copy(wExtractionNullStrategy = ExtractionNullStrategy.Disallow)
+
+  def withExtractionNullStrategy(strategy: ExtractionNullStrategy): Formats = copy(wExtractionNullStrategy = strategy)
 
   def withStrictFieldDeserialization: Formats = copy(wStrictFieldDeserialization = true)
 
@@ -506,7 +510,7 @@ trait DefaultFormats extends Formats {
   override val companions: List[(Class[_], AnyRef)] = Nil
   override val strictOptionParsing: Boolean = false
   override val emptyValueStrategy: EmptyValueStrategy = EmptyValueStrategy.default
-  override val allowNull: Boolean = true
+  override val extractionNullStrategy: ExtractionNullStrategy = ExtractionNullStrategy.Keep
   override def strictFieldDeserialization: Boolean = false
 
   val dateFormat: DateFormat = new DateFormat {

--- a/core/src/main/scala/org/json4s/prefs/ExtractionNullStrategy.scala
+++ b/core/src/main/scala/org/json4s/prefs/ExtractionNullStrategy.scala
@@ -1,0 +1,21 @@
+package org.json4s.prefs
+
+object ExtractionNullStrategy {
+
+  /**
+   * Default behaviour - keep null values
+   */
+  case object Keep extends ExtractionNullStrategy
+
+  /**
+   * Fail if null values are encountered
+   */
+  case object Disallow extends ExtractionNullStrategy
+
+  /**
+   * Filters out null values, as if they were not present
+   */
+  case object TreatAsAbsent extends ExtractionNullStrategy
+}
+
+sealed trait ExtractionNullStrategy

--- a/tests/src/test/scala/org/json4s/ExtractionBugs.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionBugs.scala
@@ -355,9 +355,18 @@ abstract class ExtractionBugs[T](mod: String) extends Specification with JsonMet
       Extraction.extract[OptionOfInt](obj) must_== OptionOfInt(None)
     }
 
+    "Extract should fail when strictOptionParsing is on and extracting from JNull" in {
+      implicit val formats = new DefaultFormats {
+        override val strictOptionParsing: Boolean = true
+      }
+
+      Extraction.extract[OptionOfInt](JNull) must throwA(
+        new MappingException("No value set for Option property: opt")
+      )
+    }
+
     Fragments.foreach(Seq[JValue](
       JNothing,
-      JNull,
       JInt(5),
       JString("---"),
       JObject(Nil),
@@ -369,7 +378,7 @@ abstract class ExtractionBugs[T](mod: String) extends Specification with JsonMet
         }
 
         Extraction.extract[OptionOfInt](obj) must throwA(
-          new MappingException("No value set for Option property: opt")
+          new MappingException("No usable value for opt\nNo value set for Option property: opt")
         )
       }
     }

--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -21,6 +21,7 @@ import org.json4s
 
 import org.specs2.mutable.Specification
 import org.json4s.native.Document
+import org.json4s.prefs.ExtractionNullStrategy
 
 class NativeExtractionExamples extends ExtractionExamples[Document]("Native", native.Serialization) with native.JsonMethods
 class JacksonExtractionExamples extends ExtractionExamples[JValue]("Jackson", jackson.Serialization) with jackson.JsonMethods
@@ -30,7 +31,11 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
   implicit lazy val formats = DefaultFormats
 
   val notNullFormats = new DefaultFormats {
-    override val allowNull = false
+    override val extractionNullStrategy = ExtractionNullStrategy.Disallow
+  }
+
+  val nullAsAbsentFormats = new DefaultFormats {
+    override val extractionNullStrategy = ExtractionNullStrategy.TreatAsAbsent
   }
 
   val strictFormats = formats.strict
@@ -368,19 +373,47 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
       parse("""{"a":[{"b":"c"}]}""").extract[Map[String, List[Map[String, String]]]] must_== Map("a" -> List(Map("b" -> "c")))
     }
 
-    "allowNull format set to false should disallow null values in extraction for class types" in {
+    "format nullExtractionStrategy set to Disallow should disallow null values in extraction for class types" in {
       parse("""{"name":"foobar","address":null}""").extract[SimplePerson](notNullFormats, Manifest.classType(classOf[SimplePerson])) must throwA(MappingException("No usable value for address\nDid not find value which can be converted into org.json4s.Address", null))
     }
 
-    "allowNull format set to false should disallow null values in extraction for primitive types" in {
+    "format nullExtractionStrategy set to TreatAsAbsent should disallow null values in extraction for class types without default values" in {
+      parse("""{"name":"foobar","address":null}""").extract[SimplePerson](nullAsAbsentFormats, Manifest.classType(classOf[SimplePerson])) must throwA(MappingException("No usable value for address\nExpected value but got null", null))
+    }
+
+    "format nullExtractionStrategy set to Disallow should disallow null values in extraction for primitive types" in {
       parse("""{"name":null}""").extract[Name](notNullFormats, Manifest.classType(classOf[Name])) must throwA(MappingException("No usable value for name\nDid not find value which can be converted into java.lang.String", null))
     }
 
-    "allowNull format set to false should extract a null Option[T] as None" in {
+    "format nullExtractionStrategy set to TreatAsAbsent should disallow null values in extraction for primitive types without default values" in {
+      parse("""{"name":null}""").extract[Name](nullAsAbsentFormats, Manifest.classType(classOf[Name])) must throwA(MappingException("No usable value for name\nExpected value but got null", null))
+    }
+
+    "format nullExtractionStrategy set to Disallow should extract a null Option[T] as None" in {
       parse("""{"name":null,"age":22}""").extract[OChild](notNullFormats, Manifest.classType(classOf[OChild])) must_== new OChild(None, 22, None, None)
     }
 
-    "allowNull format set to false should use custom null serializer to set Option[T] as None" in {
+    "format nullExtractionStrategy set to TreatAsAbsent should extract a null Option[T] as None" in {
+      parse("""{"name":null,"age":22}""").extract[OChild](nullAsAbsentFormats, Manifest.classType(classOf[OChild])) must_== new OChild(None, 22, None, None)
+    }
+
+    "format nullExtractionStrategy set to Disallow should disallow null values in extraction for class types with default values" in {
+      parse("""{"name":"foobar","address":null}""").extract[PersonWithDefaultValues](notNullFormats, Manifest.classType(classOf[PersonWithDefaultValues])) must throwA(MappingException("No usable value for address\nDid not find value which can be converted into org.json4s.Address", null))
+    }
+
+    "format nullExtractionStrategy set to TreatAsAbsent should ignore null values in extraction for class types with default values" in {
+      parse("""{"name":null}""").extract[PersonWithDefaultValues](nullAsAbsentFormats, Manifest.classType(classOf[PersonWithDefaultValues])) must_== PersonWithDefaultValues()
+    }
+
+    "format nullExtractionStrategy set to Disallow should disallow null values in extraction for collection types" in {
+      parse("""[1,null,3]""").extract[Seq[Int]](notNullFormats, implicitly) must throwA(MappingException("Did not find value which can be converted into int", null))
+    }
+
+    "format nullExtractionStrategy set to TreatAsAbsent should ignore null values in extraction for class types with default values" in {
+      parse("""[1,null,3]""").extract[Seq[Int]](nullAsAbsentFormats, implicitly) must_== Seq(1, 3)
+    }
+
+    "format nullExtractionStrategy set to Disallow should use custom null serializer to set Option[T] as None" in {
       object CustomNull extends CustomSerializer[Null](_ => ( {
         case JNothing => null
         case JNull => null
@@ -389,6 +422,17 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
         case _ => JString("")
       }))
       parse("""{"name":null,"age":22, "mother": ""}""").extract[OChild](notNullFormats + CustomNull, Manifest.classType(classOf[OChild])) must_== new OChild(None, 22, None, None)
+    }
+
+    "format nullExtractionStrategy set to TreatAsAbsent should use custom null serializer to set Option[T] as None" in {
+      object CustomNull extends CustomSerializer[Null](_ => ( {
+        case JNothing => null
+        case JNull => null
+        case JString("") => null
+      }, {
+        case _ => JString("")
+      }))
+      parse("""{"name":null,"age":22, "mother": ""}""").extract[OChild](nullAsAbsentFormats + CustomNull, Manifest.classType(classOf[OChild])) must_== new OChild(None, 22, None, None)
     }
 
     "simple case objects should be successfully extracted as a singleton instance" in {
@@ -554,6 +598,7 @@ case class Child(name: String, age: Int, birthdate: Option[java.util.Date])
 
 case class SimplePerson(name: String, address: Address)
 
+case class PersonWithDefaultValues(name: String = "No name", address: Address = Address("No street", "No city"))
 case class PersonWithMap(name: String, address: Map[String, String])
 case class PersonWithAddresses(name: String, addresses: Map[String, Address])
 

--- a/tests/src/test/scala/org/json4s/FormatsBugs.scala
+++ b/tests/src/test/scala/org/json4s/FormatsBugs.scala
@@ -1,16 +1,18 @@
 package org.json4s
 
+import org.json4s.prefs.ExtractionNullStrategy
+import org.json4s.prefs.ExtractionNullStrategy.Disallow
 import org.specs2.mutable.Specification
 
 class FormatsBugs extends Specification {
 
   "Formats" should {
-    "retain 'allowNull' setting over updates" in {
+    "retain 'extractionNullStrategy' setting over updates" in {
       val f = new DefaultFormats {
-        override val allowNull: Boolean = false
+        override val extractionNullStrategy: ExtractionNullStrategy = Disallow
       }
       val fModified = f.withBigDecimal
-      fModified.allowNull must beFalse
+      fModified.extractionNullStrategy mustEqual Disallow
     }
   }
 


### PR DESCRIPTION
Allow three different strategies for treating `null` values during extraction:
* `Keep`: Leave `null` values as they are (previously `allowNull = true`)
* `Disallow`: Fail on `null` values (previously `allowNull = false`)
* `TreatAsAbsent`: Treats `null` values as if they were not present at all, falling back to constructor default values and failing if no such are present.

Closes #671 