### PR TITLE
Making sure strictOptionParsing causes exceptions to be thrown

### DIFF
--- a/tests/src/test/scala/org/json4s/ExtractionBugs.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionBugs.scala
@@ -363,13 +363,13 @@ abstract class ExtractionBugs[T](mod: String) extends Specification with JsonMet
       JObject(Nil),
       JArray(Nil)
     )) { obj =>
-      s"Extract should fail if when strictOptionParsing is on and extracting from ${obj.toString}" in {
+      s"Extract should fail when strictOptionParsing is on and extracting from ${obj.toString}" in {
         implicit val formats = new DefaultFormats {
           override val strictOptionParsing: Boolean = true
         }
 
         Extraction.extract[OptionOfInt](obj) must throwA(
-          new MappingException("with some meaningful text")
+          new MappingException("No value set for Option property: opt")
         )
       }
     }

--- a/tests/src/test/scala/org/json4s/ExtractionBugs.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionBugs.scala
@@ -6,6 +6,8 @@ import org.json4s.native.Document
 import java.util
 import java.math.{BigDecimal => JavaBigDecimal, BigInteger => JavaBigInteger}
 
+import org.specs2.specification.core.Fragments
+
 object NativeExtractionBugs extends ExtractionBugs[Document]("Native") with native.JsonMethods
 object JacksonExtractionBugs extends ExtractionBugs[JValue]("Jackson") with jackson.JsonMethods
 
@@ -351,6 +353,25 @@ abstract class ExtractionBugs[T](mod: String) extends Specification with JsonMet
     "Extract should succeed for missing optional field" in {
       val obj = parse("""{}""".stripMargin)
       Extraction.extract[OptionOfInt](obj) must_== OptionOfInt(None)
+    }
+
+    Fragments.foreach(Seq[JValue](
+      JNothing,
+      JNull,
+      JInt(5),
+      JString("---"),
+      JObject(Nil),
+      JArray(Nil)
+    )) { obj =>
+      s"Extract should fail if when strictOptionParsing is on and extracting from ${obj.toString}" in {
+        implicit val formats = new DefaultFormats {
+          override val strictOptionParsing: Boolean = true
+        }
+
+        Extraction.extract[OptionOfInt](obj) must throwA(
+          new MappingException("with some meaningful text")
+        )
+      }
     }
   }
 }

--- a/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
+++ b/tests/src/test/scala/org/json4s/ExtractionExamplesSpec.scala
@@ -141,7 +141,7 @@ abstract class ExtractionExamples[T](mod: String, ser : json4s.Serialization) ex
       
       val mf   = implicitly[Manifest[OptionValue]]
       parse("""{"value": null}""").extract[OptionValue](fm, mf) must throwA[MappingException]
-      parse("""{}""").extract[OptionValue](fm, mf) must_== OptionValue(None)
+      parse("""{}""").extract[OptionValue](fm, mf) must throwA[MappingException]
       parse("""{"value": 1}""").extract[OptionValue](fm, mf) must_== OptionValue(Some(1))
     }
 


### PR DESCRIPTION
Fixes #465.

Note for review - one of the pre-existing unit tests got changed. But I find the new behavior intuitive.