### PR TITLE
Fix various bugs related to RichSerializer

### DIFF
--- a/core/src/main/scala/org/json4s/Extraction.scala
+++ b/core/src/main/scala/org/json4s/Extraction.scala
@@ -148,9 +148,12 @@ object Extraction {
       obj.endObject()
     }
 
+    lazy val richCustom = Formats.customRichSerializer(a)(formats)
     val custom = Formats.customSerializer(a)(formats)
     if (custom.isDefinedAt(a)) {
       current addJValue custom(a)
+    } else if (richCustom.isDefinedAt(a)) {
+      current addJValue richCustom(a)
     } else if (!serializer.isDefinedAt(a)) {
       val k = if (any != null) any.getClass else null
 
@@ -639,6 +642,7 @@ object Extraction {
       val deserializer = formats.typeHints.deserialize
       if (!deserializer.isDefinedAt(typeHint, obj)) {
         val concreteClass = formats.typeHints.classFor(typeHint) getOrElse fail("Do not know how to deserialize '" + typeHint + "'")
+
         extract(obj, typeInfo.copy(erasure = concreteClass))
       } else deserializer(typeHint, obj)
     }
@@ -763,7 +767,9 @@ object Extraction {
       case _ =>
         val typeInfo = target.typeInfo
         val custom = Formats.customDeserializer(typeInfo, json)(formats)
+        lazy val richCustom = Formats.customRichDeserializer(target, json)(formats)
         if (custom.isDefinedAt(typeInfo, json)) custom(typeInfo, json)
+        else if (richCustom.isDefinedAt(target, json)) richCustom(target, json)
         else fail("Do not know how to convert " + json + " into " + targetType)
     }
   }

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -49,6 +49,13 @@ object Formats {
       .getOrElse(PartialFunction.empty[(ScalaType, JValue), Any])
   }
 
+  private[json4s] def customRichSerializer(a: Any)(
+    implicit format: Formats): PartialFunction[Any, JValue] = {
+    format.richSerializers
+      .collectFirst { case (x) if x.serialize.isDefinedAt(a) => x.serialize }
+      .getOrElse(PartialFunction.empty[Any, JValue])
+  }
+
   private[json4s] def customDeserializer(a: (TypeInfo, JValue))(
     implicit format: Formats): PartialFunction[(TypeInfo, JValue), Any] = {
     format.customSerializers
@@ -116,7 +123,7 @@ trait Formats extends Serializable { self: Formats =>
                     wCustomSerializers: List[Serializer[_]] = self.customSerializers,
                     wCustomKeySerializers: List[KeySerializer[_]] = self.customKeySerializers,
                     wFieldSerializers: List[(Class[_], FieldSerializer[_])] = self.fieldSerializers,
-                    wRichSerializers: List[RichSerializer[_]] = List.empty,
+                    wRichSerializers: List[RichSerializer[_]] = self.richSerializers,
                     wWantsBigInt: Boolean = self.wantsBigInt,
                     wWantsBigDecimal: Boolean = self.wantsBigDecimal,
                     withPrimitives: Set[Type] = self.primitives,

--- a/tests/src/test/scala/org/json4s/RichSerializerTest.scala
+++ b/tests/src/test/scala/org/json4s/RichSerializerTest.scala
@@ -1,9 +1,11 @@
 package org.json4s
 
-import org.json4s.jackson.{JsonMethods, Serialization}
-import org.json4s.reflect.ScalaType
 import org.json4s.Extraction._
+import org.json4s.jackson.JsonMethods
+import org.json4s.reflect.{ManifestFactory, ScalaType}
 import org.specs2.mutable.Specification
+
+import scala.collection.immutable.HashMap
 
 class RichSerializerTest extends Specification {
 
@@ -32,6 +34,31 @@ class RichSerializerTest extends Specification {
     override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = ???
   }
 
+  object HashMapDeserializer extends RichSerializer[HashMap[String, _]] {
+
+    override def deserialize(implicit format: Formats): PartialFunction[(ScalaType, JValue), HashMap[String, _]] = {
+      case (scalaType, JObject(fields)) if classOf[HashMap[_, _]] == scalaType.erasure =>
+        scalaType.manifest.typeArguments match {
+          case List(_, vType) =>
+            HashMap(
+              fields.map {
+                case (k, v) => k -> extract(v)(format, vType)
+              }: _*
+            )
+        }
+    }
+
+    override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
+      case map: HashMap[_, _] =>
+        JObject {
+          map.map {
+            case (k: String, v) => k -> decompose(v)
+            case (k, _) => throw new MappingException(s"Expected String key but got $k")
+          }.toList
+        }
+    }
+  }
+
   "it" should {
     "deserialize types which have type params" in {
       implicit val formats: Formats = DefaultFormats + CustomTuple2Serializer + TypeBearerDeserializer
@@ -40,11 +67,28 @@ class RichSerializerTest extends Specification {
       extracted._2.enclosedType shouldEqual manifest[Int]
       extracted._1.enclosedType shouldEqual manifest[TypeBearer[String]]
     }
-  }
 
+    "deserialize hash maps correctly" in {
+      implicit val formats: Formats = DefaultFormats + HashMapDeserializer
+      val json = """{"map":{"foo": null, "bar": 2}}"""
+      val extracted = JsonMethods.parse(json).extract[HashMapHaver]
+      extracted shouldEqual HashMapHaver(HashMap("foo" -> None, "bar" -> Some(2)))
+    }
+
+    "be compatible with type hints" in {
+      implicit val formats: Formats = DefaultFormats.withTypeHintFieldName("hint") + HashMapDeserializer + MappedTypeHints(Map(classOf[HashMapHaver] -> "map_haver"))
+      val json = """{"map":{"foo": null, "bar": 2}, "hint": "map_haver"}"""
+      val expected = HashMapHaver(HashMap("foo" -> None, "bar" -> Some(2)))
+      val extracted = JsonMethods.parse(json).extract[SomeTrait]
+      extracted shouldEqual expected
+    }
+  }
 }
 
 case class TypeBearer[T: Manifest](name: String) {
   def enclosedType: Manifest[T] = manifest[T]
 }
 
+trait SomeTrait
+
+case class HashMapHaver(map: HashMap[String, Option[Int]]) extends SomeTrait

--- a/tests/src/test/scala/org/json4s/RichSerializerTest.scala
+++ b/tests/src/test/scala/org/json4s/RichSerializerTest.scala
@@ -68,6 +68,11 @@ class RichSerializerTest extends Specification {
       extracted._1.enclosedType shouldEqual manifest[TypeBearer[String]]
     }
 
+    "serialize with rich serializer logic" in {
+      implicit val formats: Formats = DefaultFormats + CustomTuple2Serializer
+      Extraction.decompose(("foo", 1)) shouldEqual JArray(List(JString("foo"), JInt(1)))
+    }
+
     "deserialize hash maps correctly" in {
       implicit val formats: Formats = DefaultFormats + HashMapDeserializer
       val json = """{"map":{"foo": null, "bar": 2}}"""


### PR DESCRIPTION
https://github.com/json4s/json4s/issues/689

Fixes
* Add search for rich serializer during serialization (not just deserialization)
* Add search for rich serializer in `convert` for deserialization
* Don't lose rich serializers during `Formats` copy (this was the cause of the bug with type hints)