### PR TITLE
Optimise JValueSerializer

### DIFF
--- a/jackson/src/main/scala/org/json4s/jackson/JValueSerializer.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JValueSerializer.scala
@@ -26,15 +26,16 @@ class JValueSerializer extends JsonSerializer[JValue]{
           elements foreach (x => serialize(x, json, provider))
           json.writeEndArray()
 
-        case JObject(fields) => {
+        case JObject(fields) =>
           json.writeStartObject()
-          fields filterNot (_._2 == JNothing) foreach {
+          fields foreach {
+            case (_, JNothing) => ()
             case (n, v) =>
               json.writeFieldName(n)
               serialize(v, json, provider)
           }
           json.writeEndObject()
-        }
+
         case JNull => json.writeNull()
         case JNothing => ()
       }

--- a/jackson/src/main/scala/org/json4s/jackson/JValueSerializer.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JValueSerializer.scala
@@ -18,12 +18,12 @@ class JValueSerializer extends JsonSerializer[JValue]{
         case JBool(v) => json.writeBoolean(v)
         case JArray(elements) =>
           json.writeStartArray()
-          elements filterNot (_ == JNothing) foreach (x => serialize(x, json, provider))
+          elements foreach (x => serialize(x, json, provider))
           json.writeEndArray()
 
         case JSet(elements) =>
           json.writeStartArray()
-          elements filterNot (_ == JNothing) foreach (x => serialize(x, json, provider))
+          elements foreach (x => serialize(x, json, provider))
           json.writeEndArray()
 
         case JObject(fields) => {


### PR DESCRIPTION
This PR optimises `jackson.JValueSerializer`.

Profiling a production system running constant serialization of rather big `JValues` I found out the following.

The application spends almost 17% of its time within `jackson.JValueSerializer` and 5% of its time running within `scala.collection.filterNot` (in purple in the flamegraph below).

<img width="1201" alt="filterNot-5-percent" src="https://user-images.githubusercontent.com/606963/84599838-49283580-ae75-11ea-8b65-d201d5313631.png">

This PR removes completely the calls to `filterNot` for `JArray`, `JSet` and `JObject`.
See details in the commits messages.

I expect this change to have a visible positive impact for my use case and all `json4s` users with big payloads in general.

