### PR TITLE
Feature/type hint field in mapped hints

### DIFF
--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -440,7 +440,8 @@ case class FullTypeHints(hints: List[Class[_]],
 
 /** Use a map of keys as type hints.  Values may not be mapped by multiple keys
   */
-case class MappedTypeHints(hintMap: Map[Class[_], String]) extends TypeHints {
+case class MappedTypeHints(hintMap: Map[Class[_], String],
+                           override val typeHintFieldName: String = "jsonClass") extends TypeHints {
   require(hintMap.size == hintMap.values.toList.distinct.size, "values in type hint mapping must be distinct")
 
   override val hints: List[Class[_]] = hintMap.keys.toList

--- a/tests/src/test/scala/org/json4s/RichSerializerTest.scala
+++ b/tests/src/test/scala/org/json4s/RichSerializerTest.scala
@@ -2,7 +2,7 @@ package org.json4s
 
 import org.json4s.Extraction._
 import org.json4s.jackson.JsonMethods
-import org.json4s.reflect.{ManifestFactory, ScalaType}
+import org.json4s.reflect.ScalaType
 import org.specs2.mutable.Specification
 
 import scala.collection.immutable.HashMap
@@ -81,8 +81,8 @@ class RichSerializerTest extends Specification {
     }
 
     "be compatible with type hints" in {
-      implicit val formats: Formats = DefaultFormats.withTypeHintFieldName("hint") + HashMapDeserializer + MappedTypeHints(Map(classOf[HashMapHaver] -> "map_haver"))
-      val json = """{"map":{"foo": null, "bar": 2}, "hint": "map_haver"}"""
+      implicit val formats: Formats = DefaultFormats + HashMapDeserializer + MappedTypeHints(Map(classOf[HashMapHaver] -> "map_haver"))
+      val json = """{"map":{"foo": null, "bar": 2}, "jsonClass": "map_haver"}"""
       val expected = HashMapHaver(HashMap("foo" -> None, "bar" -> Some(2)))
       val extracted = JsonMethods.parse(json).extract[SomeTrait]
       extracted shouldEqual expected


### PR DESCRIPTION
Add option to specify type hint field to `MappedTypeHints`. Includes commit from https://github.com/json4s/json4s/pull/695 so compilation succeeds.