### PR TITLE
Refactoring bestMatching() score computation

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/descriptors.scala
+++ b/core/src/main/scala/org/json4s/reflect/descriptors.scala
@@ -49,29 +49,33 @@ case class ClassDescriptor(
   properties: Seq[PropertyDescriptor]) extends ObjectDescriptor {
 
   def bestMatching(argNames: List[String]): Option[ConstructorDescriptor] = {
+    case class Score(detailed: Int, optionalCount: Int, defaultCount: Int) {
+      def isBetterThan(other: Score) = {
+          (this.detailed == other.detailed && (this.optionalCount < other.optionalCount)) ||
+          (this.detailed == other.detailed && (this.defaultCount > other.defaultCount)) ||
+          this.detailed > other.detailed
+      }
+    }
+
     val names = Set(argNames: _*)
-    def countOptionals(args: List[ConstructorParamDescriptor]) = args.count(_.isOptional)
-    def countDefaults(args: List[ConstructorParamDescriptor]) = args.count(_.hasDefault)
-    def score(args: List[ConstructorParamDescriptor]) =
-      args.foldLeft(0)((s, arg) =>
+    def score(args: List[ConstructorParamDescriptor]): Score =
+      Score(detailed = args.foldLeft(0)((s, arg) =>
         if (names.contains(arg.name)) s+1
         else if (arg.isOptional) s
         else if (arg.hasDefault) s
         else -100
+      ),
+        optionalCount = args.count(_.isOptional),
+        defaultCount = args.count(_.hasDefault)
       )
 
     if (constructors.isEmpty) None
     else {
-      val best = constructors.tail.foldLeft((constructors.head, score(constructors.head.params.toList))) { (best, c) =>
-        val newScore = score(c.params.toList)
-        val newIsBetter = {
-          (newScore == best._2 && (countOptionals(c.params.toList) < countOptionals(best._1.params.toList))) ||
-          (newScore == best._2 && (countDefaults(c.params.toList) > countDefaults(best._1.params.toList))) ||
-            newScore > best._2
-        }
-        if (newIsBetter) (c, newScore) else best
+      val best = constructors.tail.foldLeft((constructors.head, score(constructors.head.params.toList))) {
+        (best: (ConstructorDescriptor, Score), c: ConstructorDescriptor) =>
+          val newScore: Score = score(c.params.toList)
+          if (newScore.isBetterThan(best._2)) (c, newScore) else best
       }
-
       Some(best._1)
     }
   }

--- a/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
+++ b/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
@@ -1,25 +1,25 @@
 package org.json4s.reflect
 
-import org.json4s.reflect.DescriptorsSpec.{Company, Citizen, Person}
+import org.json4s.reflect.DescriptorsSpec.{Company, Citizen, Human}
 import org.specs2.mutable.Specification
 
 object DescriptorsSpec {
-  case class Person(firstName: String, lastName: String) {
+  case class Human(firstName: String, lastName: String) {
     def this(age: Int) = this("John", "Doe")
   }
-  object Person {
-    def apply(email: String) = new Person("Russell", "Westbrook")
+  object Human {
+    def apply(email: String) = new Human("Russell", "Westbrook")
   }
 
   case class Citizen(firstName: String, lastName: String, id: String) {
     def this(firstName: String, lastName: String, idAsANumber: Int) = this(firstName, lastName, idAsANumber.toString)
   }
 
-  case class Company(name: String, industry: String = "IT", ceo: Person = new Person("My", "Self"), yearFounded: Int) {
-    def this(name: String, industry: String, ceo: Person) = {
+  case class Company(name: String, industry: String = "IT", ceo: Human = new Human("My", "Self"), yearFounded: Int) {
+    def this(name: String, industry: String, ceo: Human) = {
       this(name, industry, ceo, 2000)
     }
-    def this(name: String, industry: String, ceo: Person, yearFounded: Option[Int]) = {
+    def this(name: String, industry: String, ceo: Human, yearFounded: Option[Int]) = {
       this(name, industry, ceo, yearFounded.getOrElse(2010))
     }
   }
@@ -30,7 +30,7 @@ class DescriptorsSpec extends Specification {
   "descriptors.bestMatching" should {
     "pick the natural one if arg names match exactly" in {
       // given
-      val descriptor: ClassDescriptor = describe(classOf[Person])
+      val descriptor: ClassDescriptor = describe(classOf[Human])
 
       // when
       val best = descriptor.bestMatching(List("firstName", "lastName")).get.constructor
@@ -62,7 +62,7 @@ class DescriptorsSpec extends Specification {
       val best = descriptor.bestMatching(List("name", "industry", "yearFounded")).get.constructor
 
       // test
-      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Person], classOf[Int])
+      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Human], classOf[Int])
     }
 
     "pick the most specific one (i.e. skipping defaults) if values are given, and some extras are given" in {
@@ -73,7 +73,7 @@ class DescriptorsSpec extends Specification {
       val best = descriptor.bestMatching(List("name", "industry", "yearFounded", "nonExistingProperty")).get.constructor
 
       // test
-      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Person], classOf[Int])
+      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Human], classOf[Int])
     }
 
     "pick the one using default value, not option if a value is not given" in {
@@ -84,7 +84,7 @@ class DescriptorsSpec extends Specification {
       val best = descriptor.bestMatching(List("name", "industry")).get.constructor
 
       // test
-      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Person], classOf[Int])
+      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Human], classOf[Int])
     }
 
     "pick the main one if not all values are provided" in {

--- a/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
+++ b/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
@@ -16,10 +16,10 @@ object DescriptorsSpec {
   }
 
   case class Company(name: String, industry: String = "IT", ceo: Person = new Person("My", "Self"), yearFounded: Int) {
-    def this(name: String, industry: String, ceo: Person) {
+    def this(name: String, industry: String, ceo: Person) = {
       this(name, industry, ceo, 2000)
     }
-    def this(name: String, industry: String, ceo: Person, yearFounded: Option[Int]) {
+    def this(name: String, industry: String, ceo: Person, yearFounded: Option[Int]) = {
       this(name, industry, ceo, yearFounded.getOrElse(2010))
     }
   }

--- a/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
+++ b/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
@@ -1,0 +1,83 @@
+package org.json4s.reflect
+
+import org.json4s.reflect.DescriptorsSpec.{Company, Citizen, Person}
+import org.specs2.mutable.Specification
+
+object DescriptorsSpec {
+  case class Person(firstName: String, lastName: String) {
+    def this(age: Int) = this("John", "Doe")
+  }
+  object Person {
+    def apply(email: String) = new Person("Russell", "Westbrook")
+  }
+
+  case class Citizen(firstName: String, lastName: String, id: String) {
+    def this(firstName: String, lastName: String, idAsANumber: Int) = this(firstName, lastName, idAsANumber.toString)
+  }
+
+  case class Company(name: String, industry: String = "IT", ceo: Person = new Person("My", "Self"), yearFounded: Int) {
+    def this(name: String, industry: String, ceo: Person) {
+      this(name, industry, ceo, 2000)
+    }
+    def this(name: String, industry: String, ceo: Person, yearFounded: Option[Int]) {
+      this(name, industry, ceo, yearFounded.getOrElse(2010))
+    }
+  }
+}
+
+class DescriptorsSpec extends Specification {
+
+  "descriptors.bestMatching" should {
+    "pick the natural one if arg names match exactly" in {
+      // given
+      val descriptor: ClassDescriptor = describe(classOf[Person])
+
+      // when
+      val best = descriptor.bestMatching(List("firstName", "lastName")).get.constructor
+
+      // test
+      best.constructor must_!= null
+      best.method must_== null
+      best.getParameterTypes() must_== Array(classOf[String], classOf[String])
+    }
+
+    "pick the one matching argument names" in {
+      // given
+      val descriptor: ClassDescriptor = describe(classOf[Citizen])
+
+      // when
+      val variant1 = descriptor.bestMatching(List("firstName", "lastName", "id")).get.constructor
+      val variant2 = descriptor.bestMatching(List("firstName", "lastName", "idAsANumber")).get.constructor
+
+      // test
+      variant1.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[String])
+      variant2.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Int])
+    }
+
+    "pick the most specific one (i.e. skipping defaults) if values are given" in {
+      // given
+      val descriptor: ClassDescriptor = describe(classOf[Company])
+
+      // when
+      val best = descriptor.bestMatching(List("name", "industry", "yearFounded")).get.constructor
+
+      // test
+      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Person], classOf[Int])
+    }
+
+    "pick the one using default value, not option if a value is not given" in {
+      // given
+      val descriptor: ClassDescriptor = describe(classOf[Company])
+
+      // when
+      val best = descriptor.bestMatching(List("name", "industry")).get.constructor
+
+      // test
+      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Person], classOf[Int])
+    }
+  }
+
+  private def describe(clazz: Class[_]) = {
+    Reflector.describe(Reflector.scalaTypeOf(clazz)).asInstanceOf[ClassDescriptor]
+  }
+}

--- a/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
+++ b/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
@@ -65,6 +65,17 @@ class DescriptorsSpec extends Specification {
       best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Person], classOf[Int])
     }
 
+    "pick the most specific one (i.e. skipping defaults) if values are given, and some extras are given" in {
+      // given
+      val descriptor: ClassDescriptor = describe(classOf[Company])
+
+      // when
+      val best = descriptor.bestMatching(List("name", "industry", "yearFounded", "nonExistingProperty")).get.constructor
+
+      // test
+      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Person], classOf[Int])
+    }
+
     "pick the one using default value, not option if a value is not given" in {
       // given
       val descriptor: ClassDescriptor = describe(classOf[Company])
@@ -75,6 +86,29 @@ class DescriptorsSpec extends Specification {
       // test
       best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[Person], classOf[Int])
     }
+
+    "pick the main one if not all values are provided" in {
+      // given
+      val descriptor: ClassDescriptor = describe(classOf[Citizen])
+
+      // when
+      val best = descriptor.bestMatching(List("firstName", "lastName")).get.constructor
+
+      // test
+      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[String])
+    }
+
+    "pick the main one if not all values are provided and some extras are provided" in {
+      // given
+      val descriptor: ClassDescriptor = describe(classOf[Citizen])
+
+      // when
+      val best = descriptor.bestMatching(List("firstName", "lastName", "newInfoWhichDoesNotExist")).get.constructor
+
+      // test
+      best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[String])
+    }
+
   }
 
   private def describe(clazz: Class[_]) = {

--- a/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
+++ b/tests/src/test/scala/org/json4s/reflect/DescriptorsSpec.scala
@@ -108,7 +108,6 @@ class DescriptorsSpec extends Specification {
       // test
       best.getParameterTypes() must_== Array(classOf[String], classOf[String], classOf[String])
     }
-
   }
 
   private def describe(clazz: Class[_]) = {

--- a/tests/src/test/scala/org/json4s/reflect/ReflectorSpec.scala
+++ b/tests/src/test/scala/org/json4s/reflect/ReflectorSpec.scala
@@ -27,18 +27,6 @@ case class NestedType5(dat: List[Map[Double, Option[List[Map[Long, Option[Map[By
 
 case class NestedResType[T, S, V <: Option[S]](t: T, v: V, dat: List[Map[T, V]], lis: List[List[List[List[List[S]]]]])
 
-case class Person(firstName: String, lastName: String) {
-  def this(age: Int) = this("John", "Doe")
-}
-object Person {
-  def apply(email: String) = new Person("Russell", "Westbrook")
-}
-
-case class Dog(name: String)
-
-case class Cat @PrimaryConstructor() (name: String) {
-  def this(owner: Person) = this(s"${owner.firstName}'s favorite pet'")
-}
 
 case object TheObject
 
@@ -94,6 +82,22 @@ class NormalClass {
   val primitive: Int = 1
   val optPrimitive: Option[Int] = Some(3)
 }
+
+case class PetOwner(firstName: String, lastName: String) {
+  def this(age: Int) = this("John", "Doe")
+}
+object PetOwner {
+  def apply(email: String) = new PetOwner("Russell", "Westbrook")
+}
+
+case class Dog(name: String)
+
+case class Cat @PrimaryConstructor() (name: String) {
+  def this(owner: PetOwner) = this(s"${owner.firstName}'s favorite pet'")
+}
+
+
+
 
 class ReflectorSpec extends Specification {
 
@@ -363,7 +367,7 @@ class ReflectorSpec extends Specification {
     }
 
     "discover all constructors, incl. the ones from companion object" in {
-      val klass = Reflector.scalaTypeOf(classOf[Person])
+      val klass = Reflector.scalaTypeOf(classOf[PetOwner])
       val descriptor = Reflector.describe(klass).asInstanceOf[reflect.ClassDescriptor]
 
       // the main one (with firstName, lastName Strings) is seen as two distinct ones:
@@ -372,7 +376,7 @@ class ReflectorSpec extends Specification {
     }
 
     "denote no constructor as primary if there are multiple competing" in {
-      val klass = Reflector.scalaTypeOf(classOf[Person])
+      val klass = Reflector.scalaTypeOf(classOf[PetOwner])
       val descriptor = Reflector.describe(klass).asInstanceOf[reflect.ClassDescriptor]
 
       descriptor.constructors.count(_.isPrimary) must_== 0
@@ -398,7 +402,7 @@ class ReflectorSpec extends Specification {
     }
 
     "retrieve constructors of a class in a deterministic order" in {
-      val klass = Reflector.scalaTypeOf(classOf[Person])
+      val klass = Reflector.scalaTypeOf(classOf[PetOwner])
       val descriptor = Reflector.describe(klass).asInstanceOf[reflect.ClassDescriptor]
 
       descriptor.constructors.size must_== 4


### PR DESCRIPTION
Another attempt at #685. Tests got fixed after it was reverted (#700) - artificial test case classes got mixed in the meantime and now are fine.

Pure refactoring, no change in the behavior.
Refactored the `bestMatching()` function for picking the right constructor by broadening the definition of the ad-hoc `Score` notion. The optionals and defaults have been incorporated into `Score`.

Added quite a few unit tests for this code which were missing.
