### PR TITLE
deleted sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
   include:
   - scala: 2.12.12
     jdk: openjdk11
-sudo: false
 cache:
   directories:
     - $HOME/.ivy2/cache


### PR DESCRIPTION
Since travis has moved from a container-based environment to a VM-based
environment, there is no need to specify `sudo: false` anymore.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration