### PR TITLE
add explicit return types

### DIFF
--- a/ast/src/main/scala/org/json4s/Diff.scala
+++ b/ast/src/main/scala/org/json4s/Diff.scala
@@ -104,6 +104,6 @@ object Diff {
     /** Return a diff.
      * @see org.json4s.Diff#diff
      */
-    def diff(other: JValue) = Diff.diff(this, other)
+    def diff(other: JValue): Diff = Diff.diff(this, other)
   }
 }

--- a/ast/src/main/scala/org/json4s/JsonAST.scala
+++ b/ast/src/main/scala/org/json4s/JsonAST.scala
@@ -25,7 +25,7 @@ object JsonAST {
    * concat(JInt(1), JInt(2)) == JArray(List(JInt(1), JInt(2)))
    * </pre>
    */
-  def concat(xs: JValue*) = xs.foldLeft(JNothing: JValue)(_ ++ _)
+  def concat(xs: JValue*): JValue = xs.foldLeft(JNothing: JValue)(_ ++ _)
 
   object JValue extends Merge.Mergeable
 
@@ -151,14 +151,14 @@ object JsonAST {
 
   case class JObject(obj: List[JField]) extends JValue {
     type Values = Map[String, Any]
-    def values = obj.iterator.map { case (n, v) => (n, v.values) }.toMap
+    def values: Map[String,Any] = obj.iterator.map { case (n, v) => (n, v.values) }.toMap
 
     override def equals(that: Any): Boolean = that match {
       case o: JObject => obj.toSet == o.obj.toSet
       case _ => false
     }
 
-    override def hashCode = obj.toSet[JField].hashCode
+    override def hashCode: Int = obj.toSet[JField].hashCode
   }
   case object JObject {
     def apply(fs: JField*): JObject = JObject(fs.toList)
@@ -166,7 +166,7 @@ object JsonAST {
 
   case class JArray(arr: List[JValue]) extends JValue {
     type Values = List[Any]
-    def values = arr.map(_.values)
+    def values: Values = arr.map(_.values)
     override def apply(i: Int): JValue = arr(i)
   }
 
@@ -189,7 +189,7 @@ object JsonAST {
 
   type JField = (String, JValue)
   object JField {
-    def apply(name: String, value: JValue) = (name, value)
+    def apply(name: String, value: JValue): (String, JValue) = (name, value)
 
     final class OptionStringJValue(val get: JField) extends AnyVal {
       def isEmpty: Boolean = false

--- a/ast/src/main/scala/org/json4s/JsonDSL.scala
+++ b/ast/src/main/scala/org/json4s/JsonDSL.scala
@@ -41,9 +41,9 @@ trait DoubleMode { self: Implicits =>
 }
 object DoubleMode extends Implicits with DoubleMode
 trait Implicits {
-  implicit def short2jvalue(x: Short): JValue = JInt(x)
-  implicit def byte2jvalue(x: Byte): JValue = JInt(x)
-  implicit def char2jvalue(x: Char): JValue = JInt(x)
+  implicit def short2jvalue(x: Short): JValue = JInt(x: Int)
+  implicit def byte2jvalue(x: Byte): JValue = JInt(x: Int)
+  implicit def char2jvalue(x: Char): JValue = JInt(x: Int)
   implicit def int2jvalue(x: Int): JValue = JInt(x)
   implicit def long2jvalue(x: Long): JValue = JInt(x)
   implicit def bigint2jvalue(x: BigInt): JValue = JInt(x)
@@ -67,10 +67,10 @@ object JsonDSL extends JsonDSL with DoubleMode {
 }
 trait JsonDSL extends Implicits {
 
-  implicit def seq2jvalue[A](s: Iterable[A])(implicit ev: A => JValue) =
-    JArray(s.toList.map { a => val v: JValue = a; v })
+  implicit def seq2jvalue[A](s: Iterable[A])(implicit ev: A => JValue): JArray =
+    JArray(s.toList.map(ev))
 
-  implicit def map2jvalue[A](m: Map[String, A])(implicit ev: A => JValue) =
+  implicit def map2jvalue[A](m: Map[String, A])(implicit ev: A => JValue): JObject =
     JObject(m.toList.map { case (k, v) => JField(k, v) })
 
   implicit def option2jvalue[A](opt: Option[A])(implicit ev: A => JValue): JValue = opt match {
@@ -78,11 +78,11 @@ trait JsonDSL extends Implicits {
     case None => JNothing
   }
 
-  implicit def symbol2jvalue(x: Symbol) = JString(x.name)
-  implicit def pair2jvalue[A](t: (String, A))(implicit ev: A => JValue) = JObject(List(JField(t._1, t._2)))
-  implicit def list2jvalue(l: List[JField]) = JObject(l)
-  implicit def jobject2assoc(o: JObject) = new JsonListAssoc(o.obj)
-  implicit def pair2Assoc[A](t: (String, A))(implicit ev: A => JValue) = new JsonAssoc(t)
+  implicit def symbol2jvalue(x: Symbol): JString = JString(x.name)
+  implicit def pair2jvalue[A](t: (String, A))(implicit ev: A => JValue): JObject = JObject(List(JField(t._1, t._2)))
+  implicit def list2jvalue(l: List[JField]): JObject = JObject(l)
+  implicit def jobject2assoc(o: JObject): JsonListAssoc = new JsonListAssoc(o.obj)
+  implicit def pair2Assoc[A](t: (String, A))(implicit ev: A => JValue): JsonAssoc[A] = new JsonAssoc(t)
 
   class JsonAssoc[A](left: (String, A))(implicit ev: A => JValue) {
     def ~[B](right: (String, B))(implicit ev1: B => JValue) = {

--- a/ast/src/main/scala/org/json4s/Merge.scala
+++ b/ast/src/main/scala/org/json4s/Merge.scala
@@ -32,7 +32,7 @@ private[json4s] trait MergeDep[A <: JValue, B <: JValue, R <: JValue] {
 }
 
 private[json4s] trait LowPriorityMergeDep {
-  implicit def jjj[A <: JValue, B <: JValue] = new MergeDep[A, B, JValue] {
+  implicit def jjj[A <: JValue, B <: JValue]: MergeDep[A,B,JValue] = new MergeDep[A, B, JValue] {
     def apply(val1: A, val2: B): JValue = merge(val1, val2)
 
     private def merge(val1: JValue, val2: JValue): JValue = (val1, val2) match {


### PR DESCRIPTION
Patch created with Scalafix.

I stumbled over this when trying to figure out if json4s can be ported to Dotty. Dotty demands that implicits have explicit return types.