### PR TITLE
Use provided Formats in TypeFieldSerializer

### DIFF
--- a/ext/src/main/scala/org/json4s/ext/TypeFieldSerializer.scala
+++ b/ext/src/main/scala/org/json4s/ext/TypeFieldSerializer.scala
@@ -2,12 +2,11 @@ package org.json4s.ext
 
 import org.json4s.JsonAST.{JField, JObject, JString}
 import org.json4s.reflect.{Reflector, ScalaType}
-import org.json4s.{CustomSerializer, Extraction, JValue, NoTypeHints, native}
+import org.json4s.{CustomSerializer, Extraction, JValue}
 
 
 class TypeFieldSerializer[T: Manifest](fieldName: String, mapping: Map[String, Class[_ <: T]])
-  extends CustomSerializer[T](fm => {
-    implicit val format = native.Serialization.formats(NoTypeHints)
+  extends CustomSerializer[T](implicit fm => {
     val indexByType: Map[ScalaType, String] = mapping.map { case (k, v) => Reflector.scalaTypeOf(v) -> k }
     val indexByName: Map[String, ScalaType] = mapping.mapValues(Reflector.scalaTypeOf).toMap
     val deserialize: PartialFunction[JValue, T] = {


### PR DESCRIPTION
The current implementation prevents using any other custom serializers or type hints on fields inside `T`