### PR TITLE
fixed 'http' -> 'https'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ### Issues
 
-- Questions should be posted to [stackoverflow.com](http://stackoverflow.com/questions/tagged/json4s)
+- Questions should be posted to [stackoverflow.com](https://stackoverflow.com/questions/tagged/json4s)
 - Please describe about your issue in detail (version, situation, examples)
 - We may close your issue when we have no plan to take action right now. We appreciate your understanding.
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -34,7 +34,7 @@ object build {
     pomExtra := {
       pomExtra.value ++ Group(
       <scm>
-        <url>http://github.com/json4s/json4s</url>
+        <url>https://github.com/json4s/json4s</url>
         <connection>scm:git:git://github.com/json4s/json4s.git</connection>
       </scm>
       <developers>


### PR DESCRIPTION
Sites that can be accessed via https should have URLs that start with https if possible.