### PR TITLE
use Formats.alwaysEscapeUnicode at Jackson

### DIFF
--- a/core/src/main/scala/org/json4s/ParserUtil.scala
+++ b/core/src/main/scala/org/json4s/ParserUtil.scala
@@ -45,7 +45,7 @@ object ParserUtil {
             (c >= '\u0000' && c <= '\u001f') || (c >= '\u0080' && c < '\u00a0') || (c >= '\u2000' && c < '\u2100')
           }
           if (shouldEscape)
-            appender.append("\\u%04x".format(c: Int))
+            appender.append("\\u%04X".format(c: Int))
           else appender.append(c.toString)
       }
       i += 1

--- a/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
+++ b/jackson/src/main/scala/org/json4s/jackson/JsonMethods.scala
@@ -3,6 +3,7 @@ package jackson
 
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.DeserializationFeature.{USE_BIG_DECIMAL_FOR_FLOATS, USE_BIG_INTEGER_FOR_INTS}
+import com.fasterxml.jackson.core.json._
 import scala.util.control.Exception.allCatch
 
 trait JsonMethods extends org.json4s.JsonMethods[JValue] {
@@ -40,8 +41,13 @@ trait JsonMethods extends org.json4s.JsonMethods[JValue] {
     parse(in, useBigDecimalForDouble, useBigIntForLong)
   }
 
-  def render(value: JValue)(implicit formats: Formats = DefaultFormats): JValue =
+  def render(value: JValue)(implicit formats: Formats = DefaultFormats): JValue = {
+    if (mapper.isEnabled(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature()) != formats.alwaysEscapeUnicode) {
+      mapper.getFactory().configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), formats.alwaysEscapeUnicode)
+    }
+
     formats.emptyValueStrategy.replaceEmpty(value)
+  }
 
   def compact(d: JValue): String = mapper.writeValueAsString(d)
 

--- a/tests/src/test/scala/org/json4s/native/SerializationBugs.scala
+++ b/tests/src/test/scala/org/json4s/native/SerializationBugs.scala
@@ -161,14 +161,14 @@ class SerializationBugs extends Specification {
   }
 
   "Escapes control characters" in {
-    val ser = native.Serialization.write("\u0000\u001f")
-    ser must_== "\"\\u0000\\u001f\""
+    val ser = native.Serialization.write("\u0000\u001F")
+    ser must_== "\"\\u0000\\u001F\""
   }
 
   "Escapes control and unicode characters" in {
     val formats = DefaultFormats.withEscapeUnicode
-    val ser = native.Serialization.write("\u0000\u001f")(formats)
-    ser must_== "\"\u0000\u001f\""
+    val ser = native.Serialization.write("\u0000\u001F")(formats)
+    ser must_== "\"\u0000\u001F\""
   }
 
   "classes in deeply nested objects can be serialized" in {


### PR DESCRIPTION
fix https://github.com/json4s/json4s/issues/750

In Jackson, the render method did not reference the value of Formats.alwaysEscapeUnicode.
Therefore, it was not in line with the native behavior.

Fix this problem.

Also, Jackson always uses uppercase when escaping UNICODE.
To make the results consistent, the native module now also outputs in uppercase.