### PR TITLE
Performance improvement: Change `segments` from List to Vector

### DIFF
--- a/core/src/main/scala/org/json4s/ParserUtil.scala
+++ b/core/src/main/scala/org/json4s/ParserUtil.scala
@@ -106,7 +106,7 @@ object ParserUtil {
     var curMark = -1
     var curMarkSegment = -1
     var eofIsFailure = false
-    private[this] var segments: List[Segment] = List(Segments.apply())
+    private[this] var segments: Vector[Segment] = Vector(Segments.apply())
     private[this] var segment: Array[Char] = segments.head.seg
     private[this] var cur = 0 // Pointer which points current parsing location
     private[this] var curSegmentIdx = 0 // Pointer which points current segment
@@ -163,7 +163,7 @@ object ParserUtil {
         val newSegment = Segments.apply()
         offset = 0
         segment = newSegment.seg
-        segments = segments ::: List(newSegment)
+        segments = segments :+ newSegment
         curSegmentIdx = segments.length - 1
       }
 


### PR DESCRIPTION
I was trying to read a very large Json file (> 1G) using pull parser API. I found that the bottleneck was appending to `segments` List and then accessing elements by index. Changing from List to Vector improved the performance by order of magnitude. (Scala 2.12.12)