### PR TITLE
Remove Reader.read

### DIFF
--- a/ast/shared/src/main/scala/org/json4s/JsonFormat.scala
+++ b/ast/shared/src/main/scala/org/json4s/JsonFormat.scala
@@ -5,7 +5,6 @@ import annotation.implicitNotFound
 object JsonFormat extends FormatFunctions {
   implicit def GenericFormat[T](implicit reader: Reader[T], writer: Writer[T]): JsonFormat[T] = new JsonFormat[T] {
     def write(obj: T): JValue = writer.write(obj)
-    def read(value: JValue): T = reader.read(value)
     def readEither(value: JValue) = reader.readEither(value)
   }
 }

--- a/ast/shared/src/main/scala/org/json4s/ReaderSyntax.scala
+++ b/ast/shared/src/main/scala/org/json4s/ReaderSyntax.scala
@@ -15,7 +15,10 @@ class ReaderSyntax(private val jv: JValue) extends AnyVal {
    *   JObject(JField("name", JString("Joe")) :: Nil).as[Person]
    * }}}
    */
-  def as[A](implicit reader: Reader[A]): A = reader.read(jv)
+  def as[A](implicit reader: Reader[A]): A = reader.readEither(jv) match {
+    case Right(x) => x
+    case Left(x) => throw x
+  }
 
   /**
    * Given that an implicit reader of type `A` is in scope
@@ -30,9 +33,10 @@ class ReaderSyntax(private val jv: JValue) extends AnyVal {
    *   JObject(JField("name", JString("Joe")) :: Nil).getAs[Person]
    * }}}
    */
-  def getAs[A](implicit reader: Reader[A]): Option[A] = try {
-    Option(reader.read(jv))
-  } catch { case _: Throwable => None }
+  def getAs[A](implicit reader: Reader[A]): Option[A] = reader.readEither(jv) match {
+    case Right(x) => Some(x)
+    case Left(x) => None
+  }
 
   /**
    * Given that an implicit reader of type `A` is in scope

--- a/ast/shared/src/test/scala-2/org/json4s/CaseClassJsonFormatSpec.scala
+++ b/ast/shared/src/test/scala-2/org/json4s/CaseClassJsonFormatSpec.scala
@@ -4,9 +4,10 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.Properties
 import org.scalacheck.Prop
+import org.scalatest.EitherValues
 import org.json4s.DefaultJsonFormats._
 
-class CaseClassJsonFormatSpec extends Properties("case class JsonFormat") {
+class CaseClassJsonFormatSpec extends Properties("case class JsonFormat") with EitherValues {
   private[this] val format1: JsonFormat[CaseClass22] =
     JsonFormat.format22(CaseClass22.apply, CaseClass22.unapply(_: CaseClass22).get)(
       "1",
@@ -37,6 +38,6 @@ class CaseClassJsonFormatSpec extends Properties("case class JsonFormat") {
     Arbitrary(Gen.resultOf(CaseClass22.tupled))
 
   property("case class JsonFormat") = Prop.forAll { (a: CaseClass22) =>
-    format1.read(format1.write(a)) == a
+    format1.readEither(format1.write(a)).value == a
   }
 }

--- a/ast/shared/src/test/scala-3/org/json4s/CaseClassJsonFormatSpec.scala
+++ b/ast/shared/src/test/scala-3/org/json4s/CaseClassJsonFormatSpec.scala
@@ -4,9 +4,10 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.Properties
 import org.scalacheck.Prop
+import org.scalatest.EitherValues
 import org.json4s.DefaultJsonFormats._
 
-class CaseClassJsonFormatSpec extends Properties("case class JsonFormat") {
+class CaseClassJsonFormatSpec extends Properties("case class JsonFormat") with EitherValues {
   private[this] val writerAuto: Writer[CaseClass22] =
     Writer.writerAuto(Tuple.fromProductTyped[CaseClass22])
 
@@ -66,10 +67,10 @@ class CaseClassJsonFormatSpec extends Properties("case class JsonFormat") {
     Arbitrary(Gen.resultOf(CaseClass22.apply))
 
   property("case class JsonFormat") = Prop.forAll { (a: CaseClass22) =>
-    format1.read(format1.write(a)) == a
+    format1.readEither(format1.write(a)).value == a
   }
 
   property("writerAuto") = Prop.forAll { (a: CaseClass22) =>
-    reader.read(writerAuto.write(a)) == a
+    reader.readEither(writerAuto.write(a)).value == a
   }
 }

--- a/core/src/main/scala/org/json4s/Formats.scala
+++ b/core/src/main/scala/org/json4s/Formats.scala
@@ -27,7 +27,10 @@ import scala.annotation.implicitNotFound
 
 object Formats {
 
-  def read[T](json: JValue)(implicit reader: Reader[T]): T = reader.read(json)
+  def read[T](json: JValue)(implicit reader: Reader[T]): T = reader.readEither(json) match {
+    case Right(x) => x
+    case Left(x) => throw x
+  }
 
   def write[T](obj: T)(implicit writer: Writer[T]): JValue = writer.write(obj)
 

--- a/jackson-core/src/main/scala/org/json4s/jackson/JsonMethods.scala
+++ b/jackson-core/src/main/scala/org/json4s/jackson/JsonMethods.scala
@@ -70,7 +70,10 @@ trait JsonMethods extends org.json4s.JsonMethods[JValue] {
   }
 
   def asJValue[T](obj: T)(implicit writer: Writer[T]): JValue = writer.write(obj)
-  def fromJValue[T](json: JValue)(implicit reader: Reader[T]): T = reader.read(json)
+  def fromJValue[T](json: JValue)(implicit reader: Reader[T]): T = reader.readEither(json) match {
+    case Right(x) => x
+    case Left(x) => throw x
+  }
 
   def asJsonNode(jv: JValue): JsonNode = mapper.valueToTree[JsonNode](jv)
   def fromJsonNode(jn: JsonNode): JValue = mapper.treeToValue[JValue](jn, classOf[JValue])

--- a/native-core/shared/src/test/scala/org/json4s/JsonFormatSpec.scala
+++ b/native-core/shared/src/test/scala/org/json4s/JsonFormatSpec.scala
@@ -9,16 +9,16 @@ abstract class JsonFormatSpec[T](mod: String) extends AnyWordSpec with JsonMetho
 
   import DefaultReaders._
 
-  def read[A](value: JValue)(implicit reader: Reader[A]): A = reader.read(value)
+  implicit def jvalue2readerSyntax(j: JValue): ReaderSyntax = new ReaderSyntax(j)
 
   s"$mod JsonFormat" should {
     "read a JLong" in {
       val value: JValue = JLong(42L)
 
-      assert(read[Byte](value) == (42: Byte))
-      assert(read[Short](value) == (42: Short))
-      assert(read[Int](value) == 42)
-      assert(read[Long](value) == 42L)
+      assert(value.as[Byte] == (42: Byte))
+      assert(value.as[Short] == (42: Short))
+      assert(value.as[Int] == 42)
+      assert(value.as[Long] == 42L)
     }
   }
 }


### PR DESCRIPTION
Currently 3.7.0-M9, with the addition of an abstract `readEither` to trait `Reader` makes json4s source incompatible with 3.6.x. Users of `Reader` now need to provide both `read` and `readEither.

With this change, source compatibility is still broken but users only need to provide `readEither`.