### PR TITLE
make JNumber part of hierarchy

### DIFF
--- a/ast/shared/src/main/scala/org/json4s/JValue.scala
+++ b/ast/shared/src/main/scala/org/json4s/JValue.scala
@@ -110,7 +110,7 @@ case class JString(s: String) extends JValue {
   type Values = String
   def values = s
 }
-trait JNumber
+sealed trait JNumber extends JValue
 case class JDouble(num: Double) extends JValue with JNumber {
   type Values = Double
   def values = num


### PR DESCRIPTION
Avoid scalac warning like `fruitless type test: a value of type JValue cannot also be a JNumber`.
