### PR TITLE
Fix #553 by using Java's HashSet

### DIFF
--- a/core/src/main/scala/org/json4s/reflect/descriptors.scala
+++ b/core/src/main/scala/org/json4s/reflect/descriptors.scala
@@ -2,6 +2,7 @@ package org.json4s
 package reflect
 
 import java.lang.reflect.Field
+import java.util
 
 sealed abstract class Descriptor extends Product with Serializable
 
@@ -55,7 +56,10 @@ case class ClassDescriptor(
       }
     }
 
-    val names = Set(argNames: _*)
+    val names = new util.HashSet[String]() {
+      argNames.foreach(x => add(x))
+    }
+
     def score(args: List[ConstructorParamDescriptor]): Score =
       Score(
         detailed = args.foldLeft(0)((s, arg) =>


### PR DESCRIPTION
Results of benchmark are `O(n)` (not `O(n^2)`):
```
[info] Benchmark                            (size)   Mode  Cnt       Score   Error  Units
[info] ExtractFieldsReading.json4sJackson        1  thrpt    2  901601.655          ops/s
[info] ExtractFieldsReading.json4sJackson       10  thrpt    2  299607.511          ops/s
[info] ExtractFieldsReading.json4sJackson      100  thrpt    2   34818.066          ops/s
[info] ExtractFieldsReading.json4sJackson     1000  thrpt    2    2737.936          ops/s
[info] ExtractFieldsReading.json4sJackson    10000  thrpt    2     234.466          ops/s
[info] ExtractFieldsReading.json4sJackson   100000  thrpt    2      12.504          ops/s
[info] ExtractFieldsReading.json4sJackson  1000000  thrpt    2       0.729          ops/s
[info] ExtractFieldsReading.json4sNative         1  thrpt    2  745092.795          ops/s
[info] ExtractFieldsReading.json4sNative        10  thrpt    2  223361.311          ops/s
[info] ExtractFieldsReading.json4sNative       100  thrpt    2   25438.655          ops/s
[info] ExtractFieldsReading.json4sNative      1000  thrpt    2    1986.061          ops/s
[info] ExtractFieldsReading.json4sNative     10000  thrpt    2     163.456          ops/s
[info] ExtractFieldsReading.json4sNative    100000  thrpt    2      13.090          ops/s
[info] ExtractFieldsReading.json4sNative   1000000  thrpt    2       0.445          ops/s
```