### PR TITLE
Make ext.EnumValue[E] compatible with SIP-56 match types.

### DIFF
--- a/ext/src/main/scala-3/org/json4s/ext/package.scala
+++ b/ext/src/main/scala-3/org/json4s/ext/package.scala
@@ -1,7 +1,32 @@
 package org.json4s
 
 package object ext {
-  private[this] type Aux[A] = { type Value = A }
+  /* This a hack to extract the `Value` class member of a particular `Enumeration`.
+   * To be compatible with SIP-56 match types, the type member capture `type Value = A`
+   * must correspond to a type member of the "parent" of the refinement.
+   * Usually the parent should be a class, and we would expect
+   *
+   *   type Aux[A] = Enumeration { type Value }
+   *
+   * However, that is not a legal definition in the first place, because
+   *
+   * > type Value cannot have the same name as class Value in class Enumeration
+   * > -- class definitions cannot be overridden
+   *
+   * Therefore, we cheat, and we use a structural *definition* { type Value }
+   * for the parent, which we immediately *refine* as { type Value = A }.
+   * The definition in the parent specifies that the declared bounds for Value
+   * are >: Nothing <: Any, which allows the match type to know that its type
+   * capture `a` has those bounds.
+   *
+   * ---
+   *
+   * The actual *clean* way of doing all of this would be *not* to use an
+   * `EnumValue[E]`, but instead use a `val enumeration: E` and the
+   * path-dependent type `enumeration.Value`. However, that would require a
+   * change of public API.
+   */
+  private[this] type Aux[A] = ({ type Value }) { type Value = A }
 
   private[ext] type EnumValue[A <: Enumeration] = A match {
     case Aux[a] => a

--- a/ext/src/main/scala/org/json4s/ext/EnumSerializer.scala
+++ b/ext/src/main/scala/org/json4s/ext/EnumSerializer.scala
@@ -22,7 +22,7 @@ import scala.reflect.ClassTag
 class EnumSerializer[E <: Enumeration: ClassTag](enumeration: E) extends Serializer[EnumValue[E]] {
   import JsonDSL._
 
-  private[this] val EnumerationClass = classOf[Enumeration].getClasses.find(_.getSimpleName == "Value").get
+  private[this] val EnumerationClass = classOf[Enumeration#Value]
 
   private[this] def isValid(json: JValue) = json match {
     case JInt(value) => enumeration.values.toSeq.map(_.id).contains(value.toInt)
@@ -45,7 +45,7 @@ class EnumSerializer[E <: Enumeration: ClassTag](enumeration: E) extends Seriali
 class EnumNameSerializer[E <: Enumeration: ClassTag](enumeration: E) extends Serializer[EnumValue[E]] {
   import JsonDSL._
 
-  private[this] val EnumerationClass = classOf[Enumeration].getClasses.find(_.getSimpleName == "Value").get
+  private[this] val EnumerationClass = classOf[Enumeration#Value]
 
   def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), EnumValue[E]] = {
     case (_ @TypeInfo(EnumerationClass, _), json) if isValid(json) => {

--- a/ext/src/main/scala/org/json4s/ext/EnumSerializer.scala
+++ b/ext/src/main/scala/org/json4s/ext/EnumSerializer.scala
@@ -29,16 +29,19 @@ class EnumSerializer[E <: Enumeration: ClassTag](enumeration: E) extends Seriali
     case _ => false
   }
 
+  private[this] def enumerationValueToEnumValueOfE(value: enumeration.Value): EnumValue[E] =
+    value.asInstanceOf[EnumValue[E]]
+
   def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), EnumValue[E]] = {
     case (TypeInfo(EnumerationClass, _), json) if isValid(json) =>
       json match {
-        case JInt(value) => enumeration(value.toInt)
+        case JInt(value) => enumerationValueToEnumValueOfE(enumeration(value.toInt))
         case value => throw new MappingException(s"Can't convert $value to $EnumerationClass")
       }
   }
 
   def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
-    case i: EnumValue[E] if enumeration.values.exists(_ == i) => i.id
+    case i: Enumeration#Value if enumeration.values.exists(_ == i) => i.id
   }
 }
 
@@ -47,10 +50,13 @@ class EnumNameSerializer[E <: Enumeration: ClassTag](enumeration: E) extends Ser
 
   private[this] val EnumerationClass = classOf[Enumeration#Value]
 
+  private[this] def enumerationValueToEnumValueOfE(value: enumeration.Value): EnumValue[E] =
+    value.asInstanceOf[EnumValue[E]]
+
   def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), EnumValue[E]] = {
     case (_ @TypeInfo(EnumerationClass, _), json) if isValid(json) => {
       json match {
-        case JString(value) => enumeration.withName(value)
+        case JString(value) => enumerationValueToEnumValueOfE(enumeration.withName(value))
         case value => throw new MappingException(s"Can't convert $value to $EnumerationClass")
       }
     }
@@ -62,6 +68,6 @@ class EnumNameSerializer[E <: Enumeration: ClassTag](enumeration: E) extends Ser
   }
 
   def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
-    case i: EnumValue[E] if enumeration.values.exists(_ == i) => i.toString
+    case i: Enumeration#Value if enumeration.values.exists(_ == i) => i.toString
   }
 }


### PR DESCRIPTION
See https://github.com/scala/improvement-proposals/pull/65 : SIP-56, Proper Specification for Match Types.

