### PR TITLE
Avoid ClassCastException for Scala.js

### DIFF
--- a/native-core/shared/src/main/scala/org/json4s/native/JsonParser.scala
+++ b/native-core/shared/src/main/scala/org/json4s/native/JsonParser.scala
@@ -254,8 +254,8 @@ object JsonParser {
 
     private def convert[A](x: Any, expectedType: Class[A]): A = {
       if (x == null) parser.fail("expected object or array")
-      try { x.asInstanceOf[A] }
-      catch { case _: ClassCastException => parser.fail(s"unexpected $x") }
+      if (expectedType.isInstance(x)) x.asInstanceOf[A]
+      else parser.fail(s"unexpected $x")
     }
 
     def peekOption = if (stack.isEmpty) None else Some(stack.peek)


### PR DESCRIPTION
Currently, when parsing fails, a `ClassCastException` is thrown which is undefined behavior on the Scala.js platform.

This was found when attempting to provide a cross platform version of the `JsonTest` in https://github.com/ekrich/sconfig

This PR fixes the issue which can currently be seen in CI on the topic/native branch:

Before:
```scala
[error]     at org.ekrich.config.impl.Json4sTest.invalidJsonThrows(/home/runner/work/sconfig/sconfig/sconfig/js/target/scala-2.12/sconfig-test-fastopt/main.js:37304)
[error]     at org.ekrich.config.impl.Json4sTest$scalajs$junit$bootstrapper$.invokeTest(/home/runner/work/sconfig/sconfig/sconfig/js/target/scala-2.12/sconfig-test-fastopt/main.js:37558)
[error]     at <jscode>.f$1(/home/runner/work/sconfig/sconfig/sconfig/js/target/scala-2.12/sconfig-test-fastopt/main.js:43484)
[error]     at org.scalajs.junit.JUnitTask.executeTestMethod(/home/runner/work/sconfig/sconfig/sconfig/js/target/scala-2.12/sconfig-test-fastopt/main.js:43531)
[error]     at org.scalajs.junit.JUnitTask.runTests$1(/home/runner/work/sconfig/sconfig/sconfig/js/target/scala-2.12/sconfig-test-fastopt/main.js:43754)
[error] Caused by: org.scalajs.linker.runtime.UndefinedBehaviorError: java.lang.ClassCastException: org.json4s.JObject cannot be cast to scala.Tuple2
[error]     at <jscode>.$throwClassCastException(/home/runner/work/sconfig/sconfig/sconfig/js/target/scala-2.12/sconfig-test-fastopt/main.js:52)
```
After:
```scala
[info] compiling 109 Scala sources to /Users/eric/workspace/sconfig/sconfig/js/target/scala-2.12/classes ...
[warn] two deprecations (since 2.12.0); re-run enabling -deprecation for details, or try -help
[warn] one warning found
[info] compiling 21 Scala sources to /Users/eric/workspace/sconfig/sconfig/js/target/scala-2.12/test-classes ...
[warn] multiple main classes detected: run 'show discoveredMainClasses' to see the list
[info] Fast optimizing /Users/eric/workspace/sconfig/sconfig/js/target/scala-2.12/sconfig-test-fastopt
[info] Test run started
[info] Test org.ekrich.config.impl.Json4sTest.renderingJsonStrings started
[info] Test org.ekrich.config.impl.Json4sTest.validJsonWorks started
[info] Test org.ekrich.config.impl.Json4sTest.invalidJsonThrows started
[info] Test run finished: 0 failed, 0 ignored, 3 total, 0.150208585s
[info] Passed: Total 3, Failed 0, Errors 0, Passed 3
```
