### PR TITLE
Additional gitignores for vscode and metals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,8 @@ target
 .projectile
 .lib
 atlassian-ide-plugin.xml
+.vscode
+.metals
+.bloop
+project/project
+metals.sbt


### PR DESCRIPTION
This PR implements additional gitignores for vscode and metals so I don't accidentally check code in I'm not looking to check in.
