### PR TITLE
fix: Handle dynamic constants in Java 11+ bytecode

### DIFF
--- a/scalap/src/main/scala/org/json4s/scalap/scalasig/ClassFileParser.scala
+++ b/scalap/src/main/scala/org/json4s/scalap/scalasig/ClassFileParser.scala
@@ -118,6 +118,9 @@ object ClassFileParser extends ByteCodeReader {
     pool => "MethodHandle: " + referenceKind + ", " + pool(referenceIndex)
   }
   val methodType = u2 ^^ add1 { descriptorIndex => pool => "MethodType: " + pool(descriptorIndex) }
+  val dynamic = u2 ~ u2 ^^ add1 { case bootstrapMethodAttrIndex ~ nameAndTypeIndex =>
+    pool => "Dynamic: " + "bootstrapMethodAttrIndex = " + bootstrapMethodAttrIndex + ", " + pool(nameAndTypeIndex)
+  }
   val invokeDynamic = u2 ~ u2 ^^ add1 { case bootstrapMethodAttrIndex ~ nameAndTypeIndex =>
     pool => "InvokeDynamic: " + "bootstrapMethodAttrIndex = " + bootstrapMethodAttrIndex + ", " + pool(nameAndTypeIndex)
   }
@@ -144,6 +147,7 @@ object ClassFileParser extends ByteCodeReader {
     case 12 => nameAndType
     case 15 => methodHandle
     case 16 => methodType
+    case 17 => dynamic
     case 18 => invokeDynamic
     case 19 => constantModule
     case 20 => constantPackage


### PR DESCRIPTION
Java 11 added `CONSTANT_Dynamic` to the constant pool. Generated bytecode that uses this causes json4s to fail with the following stacktrace:

```text
scala.MatchError: 17 (of class java.lang.Integer)
at org.json4s.scalap.scalasig.ClassFileParser$.$anonfun$constantPoolEntry$1(ClassFileParser.scala:133)
at org.json4s.scalap.scalasig.ClassFileParser$.$anonfun$constantPoolEntry$1$adapted(ClassFileParser.scala:133)
at org.json4s.scalap.Rule.$anonfun$flatMap$1(Rule.scala:36)
at org.json4s.scalap.Rule.$anonfun$mapResult$1(Rule.scala:46)
at org.json4s.scalap.Rules$DefaultRule.apply(Rules.scala:67)
at org.json4s.scalap.Rules$DefaultRule.apply(Rules.scala:65)
at org.json4s.scalap.StateRules.rep$2(Rules.scala:144)
at org.json4s.scalap.StateRules.$anonfun$repeatUntil$1(Rules.scala:150)
at org.json4s.scalap.Rules$DefaultRule.apply(Rules.scala:67)
at org.json4s.scalap.Rules$DefaultRule.apply(Rules.scala:65)
```

This PR updates `ClassFileParser` so that it can parse the new type.

Relevant JVM spec docs:

- https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.4
- https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.4.10
