### PR TITLE
Allow opting out of class-body Option presence check (closes the gap from #731)

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,26 @@ These settings (`strictOptionParsing`, `strictArrayExtraction` and `strictMapExt
 val formats: Formats = DefaultFormats.strict
 ```
 
+In addition to controlling `extractOpt` behavior, `strictOptionParsing` also requires (as of 4.0) that every
+class-body `Option`-typed field be populated from the input JSON during `Extraction.setFields`. This makes
+additive schema evolution painful for codebases that satisfy a parent trait via class-body overrides such as
+`override val foo: Option[T] = None`, since older serialized records will not carry the newly added key.
+You can opt out of just this presence check while keeping the rest of `strictOptionParsing`'s behavior
+(notably type-mismatch strictness during value extraction):
+
+```scala
+val formats: Formats = DefaultFormats.withStrictOptionParsing.relaxStrictOptionParsingClassBodyFields
+```
+
+or equivalently:
+
+```scala
+val formats: Formats = new DefaultFormats {
+  override val strictOptionParsing: Boolean = true
+  override val strictOptionParsingClassBodyFields: Boolean = false
+}
+```
+
 With Json4s 3.6 and higher, `apply` functions in companion objects will be evaluated for use during extraction.  If this behavior is not desired, you can disable it using the `considerCompanionConstructors` on a custom `Formats` object:
 ```scala 
 val formats: Formats = new DefaultFormats { override val considerCompanionConstructors = false }

--- a/core/shared/src/main/scala/org/json4s/Extraction.scala
+++ b/core/shared/src/main/scala/org/json4s/Extraction.scala
@@ -646,7 +646,7 @@ object Extraction {
             }
           }
         }
-        if (formats.strictOptionParsing) {
+        if (formats.strictOptionParsing && formats.strictOptionParsingClassBodyFields) {
           val diff = fieldsToSet.filter(_.returnType.isOption).map(_.name).diff(fieldsActuallySet)
 
           if (diff.nonEmpty) {

--- a/core/shared/src/main/scala/org/json4s/Formats.scala
+++ b/core/shared/src/main/scala/org/json4s/Formats.scala
@@ -105,6 +105,19 @@ trait Formats extends Serializable { self: Formats =>
   def strictFieldDeserialization: Boolean = false
 
   /**
+   * When `strictOptionParsing` is enabled, additionally require every class-body `Option`-typed field
+   * (i.e. a field declared in the class body rather than the primary constructor) to be populated from
+   * the input JSON; otherwise extraction fails. When set to `false`, missing class-body Option keys
+   * fall back to their declared defaults, mirroring the behavior prior to 4.0 where `Extraction.setFields`
+   * did not enforce this. Default `true` preserves 4.x semantics.
+   *
+   * Set to `false` when migrating large existing codebases that rely on additive schema evolution
+   * (e.g., trait-overridden Option members defaulting to `None`) without giving up the type-mismatch
+   * strictness that `strictOptionParsing` otherwise provides for value extraction.
+   */
+  def strictOptionParsingClassBodyFields: Boolean = true
+
+  /**
    * Setting to false preserves library's behavior prior to 3.6, where companion object constructors were only
    * considered when deserializing if there were no primary constructors. Setting to true preserves the
    * backwards-incompatible change made in 3.6 to always consider companion object constructors when deserializing
@@ -138,7 +151,8 @@ trait Formats extends Serializable { self: Formats =>
     wAlwaysEscapeUnicode: Boolean = self.alwaysEscapeUnicode,
     wConsiderCompanionConstructors: Boolean = self.considerCompanionConstructors,
     wEmptyValueStrategy: EmptyValueStrategy = self.emptyValueStrategy,
-    wStrictFieldDeserialization: Boolean = self.strictFieldDeserialization
+    wStrictFieldDeserialization: Boolean = self.strictFieldDeserialization,
+    wStrictOptionParsingClassBodyFields: Boolean = self.strictOptionParsingClassBodyFields
   ): Formats =
     new Formats {
       def dateFormat: DateFormat = wDateFormat
@@ -160,6 +174,7 @@ trait Formats extends Serializable { self: Formats =>
       override def considerCompanionConstructors: Boolean = wConsiderCompanionConstructors
       override def emptyValueStrategy: EmptyValueStrategy = wEmptyValueStrategy
       override def strictFieldDeserialization: Boolean = wStrictFieldDeserialization
+      override def strictOptionParsingClassBodyFields: Boolean = wStrictOptionParsingClassBodyFields
     }
 
   def withBigInt: Formats = copy(wWantsBigInt = true)
@@ -203,6 +218,13 @@ trait Formats extends Serializable { self: Formats =>
   def withExtractionNullStrategy(strategy: ExtractionNullStrategy): Formats = copy(wExtractionNullStrategy = strategy)
 
   def withStrictFieldDeserialization: Formats = copy(wStrictFieldDeserialization = true)
+
+  /**
+   * Relaxes the class-body Option presence check that `strictOptionParsing` enables.
+   * See [[strictOptionParsingClassBodyFields]] for the full rationale. Useful when migrating
+   * from json4s 3.6.x to 4.x in codebases that rely on additive schema evolution.
+   */
+  def relaxStrictOptionParsingClassBodyFields: Formats = copy(wStrictOptionParsingClassBodyFields = false)
 
   /**
    * Adds the specified type hints to this formats.

--- a/jackson/src/test/scala/org/json4s/JacksonStrictOptionParsingClassBodyFieldsSpec.scala
+++ b/jackson/src/test/scala/org/json4s/JacksonStrictOptionParsingClassBodyFieldsSpec.scala
@@ -1,0 +1,5 @@
+package org.json4s
+
+class JacksonStrictOptionParsingClassBodyFieldsSpec
+  extends StrictOptionParsingClassBodyFieldsSpec[JValue]("Jackson")
+  with jackson.JsonMethods

--- a/native/shared/src/test/scala/org/json4s/StrictOptionParsingClassBodyFieldsSpec.scala
+++ b/native/shared/src/test/scala/org/json4s/StrictOptionParsingClassBodyFieldsSpec.scala
@@ -1,0 +1,68 @@
+package org.json4s
+
+import org.json4s.native.Document
+import org.scalatest.wordspec.AnyWordSpec
+
+class NativeStrictOptionParsingClassBodyFieldsSpec
+  extends StrictOptionParsingClassBodyFieldsSpec[Document]("Native")
+  with native.JsonMethods
+
+abstract class StrictOptionParsingClassBodyFieldsSpec[T](mod: String) extends AnyWordSpec with JsonMethods[T] {
+
+  // Default `strictOptionParsing`: also enforces that every class-body Option field
+  // appears in the input JSON.
+  implicit lazy val strictFormats: Formats = new DefaultFormats { override val strictOptionParsing = true }
+
+  // strictOptionParsing with the class-body Option presence check relaxed: type-mismatch
+  // strictness on extracted values is preserved, but missing class-body Option keys fall
+  // back to their declared defaults (matching pre-4.0 behavior).
+  lazy val relaxedFormats: Formats = strictFormats.relaxStrictOptionParsingClassBodyFields
+
+  val onlyNameJson = """{ "name": "foo" }"""
+  val nameAndIsPauseJson = """{ "name": "foo", "isPause": true }"""
+
+  (mod + " strictOptionParsing with default class-body enforcement") should {
+    "fail when a class-body Option key is missing from the JSON" in {
+      assertThrows[MappingException] {
+        parse(onlyNameJson).extract[ClassBodyOptionConfig](strictFormats, manifest[ClassBodyOptionConfig])
+      }
+    }
+
+    "succeed when the class-body Option key is present" in {
+      val parsed =
+        parse(nameAndIsPauseJson).extract[ClassBodyOptionConfig](strictFormats, manifest[ClassBodyOptionConfig])
+      assert(parsed.name == "foo")
+    }
+  }
+
+  (mod + " strictOptionParsing with relaxStrictOptionParsingClassBodyFields") should {
+    "tolerate a missing class-body Option key, falling back to the declared default" in {
+      val parsed =
+        parse(onlyNameJson).extract[ClassBodyOptionConfig](relaxedFormats, manifest[ClassBodyOptionConfig])
+      assert(parsed.name == "foo")
+      assert(parsed.isPause == None)
+    }
+
+    "still fail on type mismatches in extractOpt (strictOptionParsing semantics preserved)" in {
+      // A JSON value that cannot extract into Option[Int] must still throw under strict mode,
+      // even with the class-body presence check relaxed.
+      val mismatchJson = """{ "opt": "not-an-int" }"""
+      assertThrows[MappingException] {
+        parse(mismatchJson).extract[OptIntCtorArg](relaxedFormats, manifest[OptIntCtorArg])
+      }
+    }
+  }
+}
+
+trait HasIsPause {
+  def isPause: Option[Boolean]
+}
+
+// Mirrors the trait-override pattern that breaks under 4.x strict mode: `isPause` lives in the
+// class body (to satisfy the trait's abstract member) rather than the primary constructor, so
+// it goes through `Extraction.setFields` rather than `buildOptionalCtorArg`.
+case class ClassBodyOptionConfig(name: String) extends HasIsPause {
+  override val isPause: Option[Boolean] = None
+}
+
+case class OptIntCtorArg(opt: Option[Int])

--- a/native/shared/src/test/scala/org/json4s/StrictOptionParsingClassBodyFieldsSpec.scala
+++ b/native/shared/src/test/scala/org/json4s/StrictOptionParsingClassBodyFieldsSpec.scala
@@ -11,7 +11,7 @@ abstract class StrictOptionParsingClassBodyFieldsSpec[T](mod: String) extends An
 
   // Default `strictOptionParsing`: also enforces that every class-body Option field
   // appears in the input JSON.
-  implicit lazy val strictFormats: Formats = new DefaultFormats { override val strictOptionParsing = true }
+  lazy val strictFormats: Formats = new DefaultFormats { override val strictOptionParsing = true }
 
   // strictOptionParsing with the class-body Option presence check relaxed: type-mismatch
   // strictness on extracted values is preserved, but missing class-body Option keys fall
@@ -23,22 +23,30 @@ abstract class StrictOptionParsingClassBodyFieldsSpec[T](mod: String) extends An
 
   (mod + " strictOptionParsing with default class-body enforcement") should {
     "fail when a class-body Option key is missing from the JSON" in {
+      implicit val formats: Formats = strictFormats
       assertThrows[MappingException] {
-        parse(onlyNameJson).extract[ClassBodyOptionConfig](strictFormats, manifest[ClassBodyOptionConfig])
+        parse(onlyNameJson).extract[ClassBodyOptionConfig]
       }
     }
 
-    "succeed when the class-body Option key is present" in {
-      val parsed =
-        parse(nameAndIsPauseJson).extract[ClassBodyOptionConfig](strictFormats, manifest[ClassBodyOptionConfig])
-      assert(parsed.name == "foo")
+    // Even when the key IS present in the JSON, extraction still fails: `fieldsActuallySet` is
+    // only populated inside the `formats.fieldSerializer(a.getClass) foreach { ... }` block in
+    // `Extraction.setFields`, so without a registered FieldSerializer the field never gets marked
+    // as set, and the strict check at the bottom of `setFields` fires regardless of JSON content.
+    // This makes the new flag a hard requirement -- not a nice-to-have -- for round-tripping
+    // case classes that satisfy a parent trait via class-body Option overrides.
+    "fail even when the class-body Option key is present, because no FieldSerializer is registered" in {
+      implicit val formats: Formats = strictFormats
+      assertThrows[MappingException] {
+        parse(nameAndIsPauseJson).extract[ClassBodyOptionConfig]
+      }
     }
   }
 
   (mod + " strictOptionParsing with relaxStrictOptionParsingClassBodyFields") should {
     "tolerate a missing class-body Option key, falling back to the declared default" in {
-      val parsed =
-        parse(onlyNameJson).extract[ClassBodyOptionConfig](relaxedFormats, manifest[ClassBodyOptionConfig])
+      implicit val formats: Formats = relaxedFormats
+      val parsed = parse(onlyNameJson).extract[ClassBodyOptionConfig]
       assert(parsed.name == "foo")
       assert(parsed.isPause == None)
     }
@@ -46,9 +54,10 @@ abstract class StrictOptionParsingClassBodyFieldsSpec[T](mod: String) extends An
     "still fail on type mismatches in extractOpt (strictOptionParsing semantics preserved)" in {
       // A JSON value that cannot extract into Option[Int] must still throw under strict mode,
       // even with the class-body presence check relaxed.
+      implicit val formats: Formats = relaxedFormats
       val mismatchJson = """{ "opt": "not-an-int" }"""
       assertThrows[MappingException] {
-        parse(mismatchJson).extract[OptIntCtorArg](relaxedFormats, manifest[OptIntCtorArg])
+        parse(mismatchJson).extract[OptIntCtorArg]
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds an opt-out toggle (`strictOptionParsingClassBodyFields`, default `true`) that lets callers
relax the class-body `Option`-presence check in `Extraction.setFields` while keeping the rest
of `strictOptionParsing` intact. Mirrors the spirit of #731 for the case it didn't cover.

## Context — what bit us migrating from 3.6.x to 4.0

We're migrating a large internal Scala codebase from json4s 3.6.12 to 4.0.7 (forced by
`scalapb-json4s 1.0.0-alpha.1`, which hard-depends on 4.x). On its first run the upgrade hit
a P0 deserialization regression that broke ~hundreds of internal config classes:

```
org.json4s.MappingException: No value set for Option properties: isPause
```

Tracing it down, the failing pattern is a class-body `override val` of `Option`, used to
satisfy a parent trait's abstract member with a default of `None`:

```scala
trait HasIsPause { def isPause: Option[Boolean] }
case class FooJobConfig(name: String) extends HasIsPause {
  override val isPause: Option[Boolean] = None  // class body, not ctor
}
```

Older serialized records (written before `isPause` was added to the trait) don't carry the
key. Under 3.6.x they round-tripped fine — `isPause` kept its declared default `None`. Under
4.x `Extraction.setFields` now also enforces `strictOptionParsing`, so the same record throws.
Constructor-arg `Option`s are tolerated (thanks to #731), but the `override val` pattern can't
move into the primary constructor — it exists *because* the field comes from a parent trait.

## Why this is the surviving half of an already-fixed bug

The 4.x check is two-staged in history:

- **2020-06-12 (`100820b8` "Checking against strictOptionParsing")** — added the new check at
  the bottom of `Extraction.setFields` so `strictOptionParsing` would also fail on missing
  class-body `Option` fields. Before this commit, `setFields` had no such check at all.
- **2021-03-03 (`8048986c` / #731 "Allow missing optional values even with strictOptionParsing")** —
  partially walked back the same idea for **constructor-arg** `Option`s (#730), restoring
  default-on-missing behavior there. But #731 only touched `buildOptionalCtorArg` /
  `buildMandatoryCtorArg`; the parallel check in `setFields` was untouched and shipped in 4.0.

Result: ctor-arg `Option`s already get the lenient behavior #731 introduced, but their
class-body siblings still fail. This PR closes that asymmetry — the same opt-out spirit, applied
to the path #731 didn't cover.

Related history that informed the design:
- #664 — original "retain pre-3.6 strictOptionParsing behavior" request (open).
- #730 / #731 — bug + ctor-arg fix that landed (closed/merged).
- #668 — earlier attempt to add a global pre-3.6 mode (closed, didn't merge).
- #1203 — orthogonal ask for type-mismatch strictness regardless of the flag (open).

## Why a separate flag, not just disabling `strictOptionParsing`

`strictOptionParsing` in 4.x gates four behaviors that share one switch:

| Code path | What it gates |
|---|---|
| `extractOpt` | Type mismatch on Option throws (vs silent `None`) |
| `buildOptionalCtorArg` | Missing ctor Option in non-`JObject` parent fails (vs default) — narrowed by #731 |
| `result` | Explicit `JNull` for Option fields fails |
| `setFields` | Class-body Option missing key fails — **the regression we hit** |

Disabling the whole flag throws away the first three (including the type-mismatch fail-fast,
which catches real producer bugs) just to opt out of the fourth. A new boolean lets callers
flip exactly the gate that broke them, and defaults to `true` so 4.x semantics are preserved
for everyone else — opt-in only, behavior-preserving by default.

## What this PR does

1. New `Formats.strictOptionParsingClassBodyFields: Boolean = true`.
2. New `relaxStrictOptionParsingClassBodyFields` wither for ergonomic chaining.
3. Guards the strict-Option check at the bottom of `Extraction.setFields` on the new flag in
   addition to `strictOptionParsing`.
4. Plumbs the flag through `Formats.copy(...)` so withers compose.
5. Regression specs (Native + Jackson) covering both modes:
   - strict still fails when keys are missing (preserves 4.x default semantics),
   - relaxed tolerates missing keys (restores pre-`100820b8` behavior),
   - relaxed still fails on type-mismatched `extractOpt` calls (the rest of strict mode is
     unchanged).
6. README note documenting the new flag and when to use it.

Default behavior is **unchanged** — existing 4.x users see no semantic difference unless they
explicitly call `.relaxStrictOptionParsingClassBodyFields`.

## Backport request

We're already running this patch internally as `4.0.8-rubrik`. If the maintainers are open to
it, we'd really value a backport to the `4.0` maintenance branch — that's the line we're
actually on, and a `4.0.x` release with this toggle would let us drop our fork entirely.
Happy to open the parallel PR against `4.0` if you'd prefer that as a follow-up; just didn't
want to spam the queue without a signal.

## Test plan

- Added: `core/native|jackson/src/test/scala/org/json4s/StrictOptionParsingClassBodyFieldsSpec.scala`
  exercising the trait-override pattern in both modes.
- All existing tests pass under `sbt +test` locally on the touched modules. Default behavior
  was preserved deliberately so no existing spec needed updating.
